### PR TITLE
Fix plugin build and imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Obsidian plugin to visualize tasks on a board",
   "main": "dist/main.js",
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && cp manifest.json styles.css dist/",
     "dev": "rollup -c -w",
     "test": "echo \"No tests\""
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,8 @@
+import { Plugin } from 'obsidian';
+import { BoardView, VIEW_TYPE_BOARD } from './view';
+import { BoardData, loadBoard, saveBoard, getBoardFile } from './boardStore';
+import { scanFiles, parseDependencies } from './parser';
+
 export default class VisualTasksPlugin extends Plugin {
   private board: BoardData | null = null;
 


### PR DESCRIPTION
## Summary
- copy manifest and style files during build so the `dist` folder is complete
- properly import dependencies in `main.ts`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883470af9608331b68d36ab5567ed8d