### PR TITLE
Improve task node UX

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -60,6 +60,7 @@ export class BoardView extends ItemView {
     nodeEl.style.left = pos.x + 'px';
     nodeEl.style.top = pos.y + 'px';
     nodeEl.textContent = this.tasks.get(id)?.text ?? id;
+    new ResizeObserver(() => this.drawEdges()).observe(nodeEl);
   }
 
   private registerEvents() {

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,11 @@
   background: var(--background-secondary-alt);
   border: 1px solid var(--background-modifier-border);
   border-radius: 4px;
+  resize: both;
+  overflow: hidden;
+  max-width: 260px;
+  -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 calc(100% - 1.2em), transparent 100%);
+          mask-image: linear-gradient(180deg, #000 0%, #000 calc(100% - 1.2em), transparent 100%);
 }
 .vtasks-node.selected {
   outline: 2px solid var(--color-accent);


### PR DESCRIPTION
## Summary
- make task nodes resizable
- cap task node width and add fading overflow
- redraw edges when nodes are resized

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688724b545f48331a987b492bbe40e44