### PR TITLE
Add link handles and edge relations

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -50,10 +50,18 @@ export async function scanFiles(app: App, files: TFile[]): Promise<ParsedTask[]>
 export function parseDependencies(tasks: ParsedTask[]): { from: string; to: string; type: string }[] {
   const edges: { from: string; to: string; type: string }[] = [];
   const depRegex = /dependsOn::\s*\[\[(.+?)#\^(\w+)\]\]/g;
+  const subtaskRegex = /subtaskOf::\s*\[\[(.+?)#\^(\w+)\]\]/g;
+  const seqRegex = /after::\s*\[\[(.+?)#\^(\w+)\]\]/g;
   for (const t of tasks) {
     let m: RegExpExecArray | null;
     while ((m = depRegex.exec(t.text)) !== null) {
       edges.push({ from: t.blockId, to: m[2], type: 'depends' });
+    }
+    while ((m = subtaskRegex.exec(t.text)) !== null) {
+      edges.push({ from: m[2], to: t.blockId, type: 'subtask' });
+    }
+    while ((m = seqRegex.exec(t.text)) !== null) {
+      edges.push({ from: m[2], to: t.blockId, type: 'sequence' });
     }
   }
   return edges;

--- a/styles.css
+++ b/styles.css
@@ -16,15 +16,56 @@
   -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 calc(100% - 1.2em), transparent 100%);
           mask-image: linear-gradient(180deg, #000 0%, #000 calc(100% - 1.2em), transparent 100%);
 }
+
+.vtasks-text {
+  pointer-events: none;
+}
 .vtasks-node.selected {
   outline: 2px solid var(--color-accent);
 }
 
 .vtasks-edges {
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .vtasks-edge {
   stroke: var(--text-muted);
   stroke-width: 1.5px;
+  fill: none;
+  cursor: pointer;
+  pointer-events: stroke;
+}
+
+.vtasks-edge-depends {
+  stroke: var(--color-accent);
+}
+
+.vtasks-edge-subtask {
+  stroke: var(--color-yellow);
+  stroke-dasharray: 4 2;
+}
+
+.vtasks-edge-sequence {
+  stroke: var(--color-green);
+  stroke-dasharray: 2 2;
+}
+
+.vtasks-handle {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-accent);
+}
+
+.vtasks-handle-in {
+  left: -5px;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.vtasks-handle-out {
+  right: -5px;
+  top: 50%;
+  transform: translate(50%, -50%);
 }


### PR DESCRIPTION
## Summary
- support detecting `subtaskOf` and `after` relations in parser
- update controller to manage relations in markdown text
- add draggable input/output handles and curved edges
- change edge appearance depending on relation type
- allow clicking edges to cycle their relation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688726b63e6083318c59a6b8bdf541fc