### PR TITLE
Add double-click to open tasks from board

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -42,6 +42,16 @@ export default class Controller {
     return id;
   }
 
+  async openTask(id: string) {
+    const task = this.tasks.get(id);
+    if (!task) return;
+    await this.app.workspace.openLinkText(
+      `${task.file.path}#^${task.blockId}`,
+      '',
+      true
+    );
+  }
+
   async toggleCheck(id: string) {
     const task = this.tasks.get(id);
     if (!task) return;

--- a/src/view.ts
+++ b/src/view.ts
@@ -68,6 +68,11 @@ export class BoardView extends ItemView {
     const outHandle = nodeEl.createDiv('vtasks-handle vtasks-handle-out');
 
     new ResizeObserver(() => this.drawEdges()).observe(nodeEl);
+
+    nodeEl.addEventListener('dblclick', (e) => {
+      e.stopPropagation();
+      this.controller.openTask(id);
+    });
   }
 
   private registerEvents() {


### PR DESCRIPTION
## Summary
- let Controller open tasks by path and block ID
- open tasks on node double-click

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68872b22894c8331973c0e330521f0e5