### PR TITLE
Add plugin settings and settings tab

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2,13 +2,15 @@ import { App, normalizePath, TFile } from 'obsidian';
 import crypto from 'crypto';
 import { BoardData, saveBoard } from './boardStore';
 import { ParsedTask } from './parser';
+import { PluginSettings } from './settings';
 
 export default class Controller {
   constructor(
     private app: App,
     private boardFile: TFile,
     private board: BoardData,
-    private tasks: Map<string, ParsedTask>
+    private tasks: Map<string, ParsedTask>,
+    private settings: PluginSettings
   ) {}
 
   async moveNode(id: string, x: number, y: number) {
@@ -17,7 +19,12 @@ export default class Controller {
     await saveBoard(this.app, this.boardFile, this.board);
   }
 
-  async createTask(text: string, x: number, y: number, filePath = 'Tasks.md') {
+  async createTask(
+    text: string,
+    x: number,
+    y: number,
+    filePath = this.settings.defaultTaskFile
+  ) {
     const path = normalizePath(filePath);
     let file = this.app.vault.getAbstractFileByPath(path) as TFile;
     if (!file) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,49 @@
+import { App, PluginSettingTab, Setting } from 'obsidian';
+import VisualTasksPlugin from './main';
+
+export interface PluginSettings {
+  boardFilePath: string;
+  defaultTaskFile: string;
+}
+
+export const DEFAULT_SETTINGS: PluginSettings = {
+  boardFilePath: 'tasks.vtasks.json',
+  defaultTaskFile: 'Tasks.md',
+};
+
+export class SettingsTab extends PluginSettingTab {
+  constructor(app: App, private plugin: VisualTasksPlugin) {
+    super(app, plugin);
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName('Board JSON path')
+      .setDesc('Location where board data is stored')
+      .addText((text) =>
+        text
+          .setPlaceholder('tasks.vtasks.json')
+          .setValue(this.plugin.settings.boardFilePath)
+          .onChange(async (value) => {
+            this.plugin.settings.boardFilePath = value.trim();
+            await this.plugin.saveData(this.plugin.settings);
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Default note for tasks')
+      .setDesc('File used when creating new tasks')
+      .addText((text) =>
+        text
+          .setPlaceholder('Tasks.md')
+          .setValue(this.plugin.settings.defaultTaskFile)
+          .onChange(async (value) => {
+            this.plugin.settings.defaultTaskFile = value.trim();
+            await this.plugin.saveData(this.plugin.settings);
+          })
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- add a PluginSettings interface and SettingsTab for configuration
- load settings in the plugin and provide them to the Controller
- use configured board JSON path instead of hardcoded value
- use default note path when creating tasks

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68872b61521c83319f16a3f641d222ec