### PR TITLE
Implement board refresh on vault changes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,16 @@ export default class VisualTasksPlugin extends Plugin {
       return new BoardView(leaf, this.controller!, this.board!, this.tasks);
     });
 
+    this.registerEvent(
+      this.app.vault.on('create', () => this.refreshFromVault())
+    );
+    this.registerEvent(
+      this.app.vault.on('modify', () => this.refreshFromVault())
+    );
+    this.registerEvent(
+      this.app.vault.on('delete', () => this.refreshFromVault())
+    );
+
     this.addCommand({
       id: 'open-board',
       name: 'Open Tasks Board',
@@ -51,5 +61,46 @@ export default class VisualTasksPlugin extends Plugin {
 
     const leaf = this.app.workspace.getLeaf(true);
     await leaf.setViewState({ type: VIEW_TYPE_BOARD, active: true });
+  }
+
+  private async refreshFromVault() {
+    if (!this.board || !this.boardFile) return;
+
+    const files = this.app.vault.getMarkdownFiles();
+    const parsed = await scanFiles(this.app, files);
+    const deps = parseDependencies(parsed);
+
+    this.tasks.clear();
+    for (const task of parsed) {
+      this.tasks.set(task.blockId, task);
+      if (!this.board.nodes[task.blockId]) {
+        this.board.nodes[task.blockId] = { x: 20, y: 20 };
+      }
+    }
+
+    for (const id of Object.keys(this.board.nodes)) {
+      if (!this.tasks.has(id)) delete this.board.nodes[id];
+    }
+
+    this.board.edges = this.board.edges.filter(
+      (e) => this.tasks.has(e.from) && this.tasks.has(e.to)
+    );
+
+    for (const dep of deps) {
+      if (
+        !this.board.edges.find(
+          (e) => e.from === dep.from && e.to === dep.to && e.type === dep.type
+        )
+      ) {
+        this.board.edges.push(dep);
+      }
+    }
+
+    await saveBoard(this.app, this.boardFile, this.board);
+
+    const leaf = this.app.workspace.getLeavesOfType(VIEW_TYPE_BOARD)[0];
+    if (leaf) {
+      (leaf.view as BoardView).updateData(this.board, this.tasks);
+    }
   }
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -38,6 +38,12 @@ export class BoardView extends ItemView {
     this.render();
   }
 
+  updateData(board: BoardData, tasks: Map<string, ParsedTask>) {
+    this.board = board;
+    this.tasks = tasks;
+    this.render();
+  }
+
   private render() {
     this.containerEl.empty();
     this.boardEl = this.containerEl.createDiv('vtasks-board');


### PR DESCRIPTION
## Summary
- listen for vault changes in `onload`
- rescan markdown tasks when vault files change
- update board data and refresh BoardView
- allow BoardView to update data dynamically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68872b685374833184eb148b294a0f02