### PR TITLE
Add task filtering by tags and folders

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,11 +4,15 @@ import VisualTasksPlugin from './main';
 export interface PluginSettings {
   boardFilePath: string;
   defaultTaskFile: string;
+  tagFilters: string[];
+  folderPaths: string[];
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
   boardFilePath: 'tasks.vtasks.json',
   defaultTaskFile: 'Tasks.md',
+  tagFilters: [],
+  folderPaths: [],
 };
 
 export class SettingsTab extends PluginSettingTab {
@@ -42,6 +46,38 @@ export class SettingsTab extends PluginSettingTab {
           .setValue(this.plugin.settings.defaultTaskFile)
           .onChange(async (value) => {
             this.plugin.settings.defaultTaskFile = value.trim();
+            await this.plugin.saveData(this.plugin.settings);
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Tag filters')
+      .setDesc('Comma separated list of tags to include')
+      .addText((text) =>
+        text
+          .setPlaceholder('#tag1, #tag2')
+          .setValue(this.plugin.settings.tagFilters.join(', '))
+          .onChange(async (value) => {
+            this.plugin.settings.tagFilters = value
+              .split(',')
+              .map((v) => v.trim().replace(/^#/, ''))
+              .filter((v) => v.length > 0);
+            await this.plugin.saveData(this.plugin.settings);
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Folder filters')
+      .setDesc('Comma separated list of folders to include')
+      .addText((text) =>
+        text
+          .setPlaceholder('Path/To/Folder')
+          .setValue(this.plugin.settings.folderPaths.join(', '))
+          .onChange(async (value) => {
+            this.plugin.settings.folderPaths = value
+              .split(',')
+              .map((v) => v.trim())
+              .filter((v) => v.length > 0);
             await this.plugin.saveData(this.plugin.settings);
           })
       );


### PR DESCRIPTION
## Summary
- support tag and folder filters in plugin settings
- filter tasks when scanning files
- add filter controls to the board view
- allow board view to update filters through plugin

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68872c65d6a08331a07aa383ce98fb77