### PR TITLE
Add context menu for tasks

### DIFF
--- a/src/boardStore.ts
+++ b/src/boardStore.ts
@@ -1,8 +1,14 @@
 import { App, normalizePath, TFile } from 'obsidian';
 
+export interface NodeData {
+  x: number;
+  y: number;
+  color?: string;
+}
+
 export interface BoardData {
   version: number;
-  nodes: Record<string, { x: number; y: number }>;
+  nodes: Record<string, NodeData>;
   edges: { from: string; to: string; type: string }[];
 }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf } from 'obsidian';
+import { ItemView, WorkspaceLeaf, Menu } from 'obsidian';
 import Controller from './controller';
 import { BoardData } from './boardStore';
 import { ParsedTask } from './parser';
@@ -67,6 +67,7 @@ export class BoardView extends ItemView {
     nodeEl.setAttr('data-id', id);
     nodeEl.style.left = pos.x + 'px';
     nodeEl.style.top = pos.y + 'px';
+    if (pos.color) nodeEl.style.borderColor = pos.color;
 
     const inHandle = nodeEl.createDiv('vtasks-handle vtasks-handle-in');
     const textEl = nodeEl.createDiv('vtasks-text');
@@ -117,7 +118,7 @@ export class BoardView extends ItemView {
         const y = (e as PointerEvent).clientY - boardRect.top - this.dragOffsetY;
         nodeEl.style.left = x + 'px';
         nodeEl.style.top = y + 'px';
-        this.board.nodes[id] = { x, y };
+        this.board.nodes[id] = { ...this.board.nodes[id], x, y };
         this.drawEdges();
       } else if (this.edgeStart && this.tempEdge) {
         const boardRect = this.boardEl.getBoundingClientRect();
@@ -165,6 +166,31 @@ export class BoardView extends ItemView {
       } else {
         this.clearSelection();
       }
+    });
+
+    this.boardEl.addEventListener('contextmenu', (e) => {
+      const target = (e.target as HTMLElement).closest('.vtasks-node') as HTMLElement | null;
+      if (!target) return;
+      e.preventDefault();
+      const id = target.getAttribute('data-id')!;
+      const menu = new Menu();
+      const colors = ['red', 'green', 'blue', 'yellow', ''];
+      colors.forEach((c) => {
+        const title = c ? `Outline ${c}` : 'Default outline';
+        menu.addItem((item) =>
+          item.setTitle(title).onClick(() => {
+            target.style.borderColor = c ? c : '';
+            this.controller.setNodeColor(id, c || null).then(() => this.render());
+          })
+        );
+      });
+      const checked = this.tasks.get(id)?.checked ?? false;
+      menu.addItem((item) =>
+        item
+          .setTitle(checked ? 'Mark not done' : 'Mark done')
+          .onClick(() => this.controller.setCheck(id, !checked).then(() => this.render()))
+      );
+      menu.showAtMouseEvent(e as MouseEvent);
     });
 
     this.boardEl.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- support node color metadata and add NodeData type
- add methods to set task status and node color
- update view to show a context menu on right-click to change outline color and toggle status

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68872cb4c2308331bcad2c3b30199626