### PR TITLE
Add grid alignment and snap features

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,27 @@
   position: relative;
   width: 100%;
   height: 100%;
+  background-image: radial-gradient(var(--background-modifier-border) 1px, transparent 0);
+  background-size: 20px 20px;
+}
+
+.vtasks-align-line {
+  position: absolute;
+  background: var(--color-accent);
+  pointer-events: none;
+  z-index: 5;
+}
+
+.vtasks-align-v {
+  width: 1px;
+  top: 0;
+  bottom: 0;
+}
+
+.vtasks-align-h {
+  height: 1px;
+  left: 0;
+  right: 0;
 }
 
 .vtasks-node {


### PR DESCRIPTION
## Summary
- render dotted grid background
- snap task nodes to grid and show alignment lines

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68872ea419fc8331999d319eade94f40