### PR TITLE
Add grouping functionality to tasks board

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This experimental Obsidian plugin lets you manage markdown tasks on an interactive board.
 
 All tasks in your vault are parsed and shown as draggable nodes. Positions and connections are stored in `*.vtasks.json` files next to your notes. Nodes can be moved with the mouse, dependencies are drawn as lines and several keyboard shortcuts allow quick editing directly from the board.
+Tasks can also be selected with a rectangle and grouped into collapsible boxes.
 
 ## Development
 

--- a/src/boardStore.ts
+++ b/src/boardStore.ts
@@ -4,6 +4,10 @@ export interface NodeData {
   x: number;
   y: number;
   color?: string;
+  type?: 'group';
+  name?: string;
+  members?: string[];
+  group?: string;
 }
 
 export interface BoardData {

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,11 +109,14 @@ export default class VisualTasksPlugin extends Plugin {
     }
 
     for (const id of Object.keys(this.board.nodes)) {
-      if (!this.tasks.has(id)) delete this.board.nodes[id];
+      const n = this.board.nodes[id] as any;
+      if (!this.tasks.has(id) && n.type !== 'group') delete this.board.nodes[id];
     }
 
     this.board.edges = this.board.edges.filter(
-      (e) => this.tasks.has(e.from) && this.tasks.has(e.to)
+      (e) =>
+        (this.tasks.has(e.from) || this.board.nodes[e.from]?.type === 'group') &&
+        (this.tasks.has(e.to) || this.board.nodes[e.to]?.type === 'group')
     );
 
     for (const dep of deps) {

--- a/styles.css
+++ b/styles.css
@@ -90,3 +90,33 @@
   top: 50%;
   transform: translate(50%, -50%);
 }
+
+.vtasks-selection {
+  position: absolute;
+  border: 1px dashed var(--color-accent);
+  background-color: rgba(var(--color-accent-rgb), 0.1);
+  pointer-events: none;
+  z-index: 10;
+}
+
+.vtasks-group {
+  background: var(--background-secondary);
+}
+
+.vtasks-group-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  margin-top: 4px;
+}
+
+.vtasks-group-box {
+  width: 8px;
+  height: 8px;
+  background: var(--background-modifier-border);
+}
+
+.vtasks-group-count {
+  font-size: 0.8em;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- allow creating group nodes in the board data
- implement grouping/ungrouping in the controller
- keep group nodes on refresh and maintain edges
- support rectangle selection and grouping in the board view
- add styles for selection rectangles and group previews
- document grouping capability

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68872f7f02988331948ebe865200e91a