### PR TITLE
Fix frequent view refresh

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, TFile } from 'obsidian';
+import { Plugin, TFile, TAbstractFile } from 'obsidian';
 import { BoardView, VIEW_TYPE_BOARD } from './view';
 import { BoardData, loadBoard, saveBoard, getBoardFile } from './boardStore';
 import { scanFiles, parseDependencies, ParsedTask, ScanOptions } from './parser';
@@ -29,15 +29,13 @@ export default class VisualTasksPlugin extends Plugin {
       );
     });
 
-    this.registerEvent(
-      this.app.vault.on('create', () => this.refreshFromVault())
-    );
-    this.registerEvent(
-      this.app.vault.on('modify', () => this.refreshFromVault())
-    );
-    this.registerEvent(
-      this.app.vault.on('delete', () => this.refreshFromVault())
-    );
+    const onVaultChange = (file: TAbstractFile) => {
+      if (this.boardFile && file.path === this.boardFile.path) return;
+      this.refreshFromVault();
+    };
+    this.registerEvent(this.app.vault.on('create', onVaultChange));
+    this.registerEvent(this.app.vault.on('modify', onVaultChange));
+    this.registerEvent(this.app.vault.on('delete', onVaultChange));
 
     this.addCommand({
       id: 'open-board',


### PR DESCRIPTION
## Summary
- avoid refreshing the board view when the board file is modified by the plugin

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887357d95b88331b31ca230c570cacb