### PR TITLE
Fix task edge relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This experimental Obsidian plugin lets you manage markdown tasks on an interacti
 All tasks in your vault are parsed and shown as draggable nodes. Positions and connections are stored in `*.vtasks.json` files next to your notes. Nodes can be moved with the mouse, dependencies are drawn as lines and several keyboard shortcuts allow quick editing directly from the board.
 Tasks can also be selected with a rectangle and grouped into collapsible boxes.
 
+Edges support different relationship types: dependency, subtask and sequence. Click an edge to cycle through these types and the line style will update accordingly.
+
 ## Development
 
 Install dependencies and build the plugin:

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -158,10 +158,18 @@ export default class Controller {
   private async applyRelation(type: string, from: ParsedTask, to: ParsedTask) {
     const rel = this.relationString(type, from, to);
     if (!rel) return;
+    const insertRel = (t: string) => {
+      if (t.includes(rel)) return t;
+      const match = t.match(/\^([\w-]+)$/);
+      if (match) {
+        return t.replace(/\^([\w-]+)$/, `${rel} ^$1`);
+      }
+      return `${t} ${rel}`;
+    };
     if (type === 'depends') {
-      await this.modifyTaskText(from, (t) => (t.includes(rel) ? t : `${t} ${rel}`));
+      await this.modifyTaskText(from, insertRel);
     } else {
-      await this.modifyTaskText(to, (t) => (t.includes(rel) ? t : `${t} ${rel}`));
+      await this.modifyTaskText(to, insertRel);
     }
   }
 


### PR DESCRIPTION
## Summary
- keep block ID at end of task text when adding relations
- document how to switch edge types

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68873d23b6b8833191a45c94951b9fc0