### PR TITLE
Fix dependency edge orientation

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -166,22 +166,14 @@ export default class Controller {
       }
       return `${t} ${rel}`;
     };
-    if (type === 'depends') {
-      await this.modifyTaskText(from, insertRel);
-    } else {
-      await this.modifyTaskText(to, insertRel);
-    }
+    await this.modifyTaskText(to, insertRel);
   }
 
   private async removeRelation(type: string, from: ParsedTask, to: ParsedTask) {
     const rel = this.relationString(type, from, to);
     if (!rel) return;
     const re = new RegExp(`\\s*${rel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
-    if (type === 'depends') {
-      await this.modifyTaskText(from, (t) => t.replace(re, ''));
-    } else {
-      await this.modifyTaskText(to, (t) => t.replace(re, ''));
-    }
+    await this.modifyTaskText(to, (t) => t.replace(re, ''));
   }
 
   async createEdge(from: string, to: string, type: string) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -69,7 +69,7 @@ export function parseDependencies(tasks: ParsedTask[]): { from: string; to: stri
   for (const t of tasks) {
     let m: RegExpExecArray | null;
     while ((m = depRegex.exec(t.text)) !== null) {
-      edges.push({ from: t.blockId, to: m[2], type: 'depends' });
+      edges.push({ from: m[2], to: t.blockId, type: 'depends' });
     }
     while ((m = subtaskRegex.exec(t.text)) !== null) {
       edges.push({ from: m[2], to: t.blockId, type: 'subtask' });


### PR DESCRIPTION
## Summary
- ensure `dependsOn` edges point from dependency to task
- modify relation helpers to write dependency relations on the target task

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887471e99f083318ca5b76eff5921ab