### PR TITLE
Add context menu for edges

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -199,4 +199,28 @@ export default class Controller {
     edge.type = next;
     await saveBoard(this.app, this.boardFile, this.board);
   }
+
+  async setEdgeType(index: number, type: string) {
+    const edge = this.board.edges[index];
+    if (!edge || edge.type === type) return;
+    const fromTask = this.tasks.get(edge.from);
+    const toTask = this.tasks.get(edge.to);
+    if (!fromTask || !toTask) return;
+    await this.removeRelation(edge.type, fromTask, toTask);
+    await this.applyRelation(type, fromTask, toTask);
+    edge.type = type;
+    await saveBoard(this.app, this.boardFile, this.board);
+  }
+
+  async deleteEdge(index: number) {
+    const edge = this.board.edges[index];
+    if (!edge) return;
+    const fromTask = this.tasks.get(edge.from);
+    const toTask = this.tasks.get(edge.to);
+    if (fromTask && toTask) {
+      await this.removeRelation(edge.type, fromTask, toTask);
+    }
+    this.board.edges.splice(index, 1);
+    await saveBoard(this.app, this.boardFile, this.board);
+  }
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -444,6 +444,31 @@ export class BoardView extends ItemView {
         this.controller.cycleEdgeType(idx).then(() => this.render());
       }
     });
+
+    this.svgEl.addEventListener('contextmenu', (e) => {
+      const edgeEl = (e.target as HTMLElement).closest('path.vtasks-edge') as SVGPathElement | null;
+      if (!edgeEl || !edgeEl.getAttr('data-index')) return;
+      e.preventDefault();
+      const idx = parseInt(edgeEl.getAttr('data-index')!);
+      const edge = this.board.edges[idx];
+      if (!edge) return;
+      const menu = new Menu();
+      const types = ['depends', 'subtask', 'sequence'];
+      types.forEach((t) => {
+        const title = edge.type === t ? `✔ ${t}` : t;
+        menu.addItem((item) =>
+          item.setTitle(title).onClick(() => {
+            this.controller.setEdgeType(idx, t).then(() => this.render());
+          })
+        );
+      });
+      menu.addItem((item) =>
+        item.setTitle('Delete connection').onClick(() => {
+          this.controller.deleteEdge(idx).then(() => this.render());
+        })
+      );
+      menu.showAtMouseEvent(e as MouseEvent);
+    });
   }
 
   private selectNode(el: HTMLElement, id: string, additive = false) {


### PR DESCRIPTION
## Summary
- support setting and deleting edge types with new `Controller` methods
- add edge context menu in the board view

## Testing
- `npm test`
- `npm run build` *(fails: rollup not found until dependencies installed)*

------
https://chatgpt.com/codex/tasks/task_e_68874d30f0f4833183cd6a180bae7796