### PR TITLE
Increase hit box for edges

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -502,12 +502,20 @@ export class BoardView extends ItemView {
       const y1 = fr.top - boardRect.top + fr.height / 2;
       const x2 = tr.left - boardRect.left + tr.width / 2;
       const y2 = tr.top - boardRect.top + tr.height / 2;
-      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
       const dx = Math.abs(x2 - x1);
-      path.setAttr('d', `M${x1} ${y1} C ${x1 + dx / 2} ${y1}, ${x2 - dx / 2} ${y2}, ${x2} ${y2}`);
-      path.classList.add('vtasks-edge', `vtasks-edge-${edge.type}`);
-      path.setAttr('data-index', String(idx));
-      this.svgEl.appendChild(path);
+      const d = `M${x1} ${y1} C ${x1 + dx / 2} ${y1}, ${x2 - dx / 2} ${y2}, ${x2} ${y2}`;
+
+      const hit = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      hit.setAttr('d', d);
+      hit.classList.add('vtasks-edge');
+      hit.setAttr('data-index', String(idx));
+      this.svgEl.appendChild(hit);
+
+      const line = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      line.setAttr('d', d);
+      line.classList.add('vtasks-edge-line', `vtasks-edge-${edge.type}`);
+      line.setAttr('data-index', String(idx));
+      this.svgEl.appendChild(line);
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -54,23 +54,30 @@
 }
 
 .vtasks-edge {
-  stroke: var(--text-muted);
-  stroke-width: 1.5px;
+  stroke: transparent;
+  stroke-width: 10px;
   fill: none;
   cursor: pointer;
   pointer-events: stroke;
 }
 
-.vtasks-edge-depends {
+.vtasks-edge-line {
+  stroke: var(--text-muted);
+  stroke-width: 1.5px;
+  fill: none;
+  pointer-events: none;
+}
+
+.vtasks-edge-line.vtasks-edge-depends {
   stroke: var(--color-accent);
 }
 
-.vtasks-edge-subtask {
+.vtasks-edge-line.vtasks-edge-subtask {
   stroke: var(--color-yellow);
   stroke-dasharray: 4 2;
 }
 
-.vtasks-edge-sequence {
+.vtasks-edge-line.vtasks-edge-sequence {
   stroke: var(--color-green);
   stroke-dasharray: 2 2;
 }


### PR DESCRIPTION
## Summary
- enlarge the interactive area for edges to make right-clicking easier
- implement invisible overlay paths for edges

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887689a4b90833187093b2e81f6ee67