### PR TITLE
Fix tag placement

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -138,9 +138,8 @@ export class BoardView extends ItemView {
     if (pos.color) nodeEl.style.borderColor = pos.color;
 
     const inHandle = nodeEl.createDiv('vtasks-handle vtasks-handle-in');
-    const metaEl = nodeEl.createDiv('vtasks-meta');
     const textEl = nodeEl.createDiv('vtasks-text');
-    const tagsEl = nodeEl.createDiv('vtasks-tags');
+    const metaEl = nodeEl.createDiv('vtasks-meta');
     if (pos.type === 'group') {
       nodeEl.addClass('vtasks-group');
       textEl.textContent = pos.name || 'Group';
@@ -171,6 +170,7 @@ export class BoardView extends ItemView {
       }
       textEl.textContent = text.trim();
       metas.forEach((m) => metaEl.createSpan({ text: m }));
+      const tagsEl = metaEl.createDiv('vtasks-tags');
       tags.forEach((t) => tagsEl.createSpan({ text: t, cls: 'vtasks-tag' }));
       if (task?.checked) nodeEl.addClass('done');
     }

--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,9 @@
 
 .vtasks-node {
   position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   padding: 4px 8px;
   background: var(--background-secondary-alt);
   border: 1px solid var(--background-modifier-border);


### PR DESCRIPTION
## Summary
- keep metadata and tags together in `BoardView`
- flex layout for board nodes so metadata sticks to bottom

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688770e53d608331914310e7c832122a