### PR TITLE
Add zooming capability to board view

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This experimental Obsidian plugin lets you manage markdown tasks on an interacti
 
 All tasks in your vault are parsed and shown as draggable nodes. Positions and connections are stored in `*.vtasks.json` files next to your notes. Nodes can be moved with the mouse, dependencies are drawn as lines and several keyboard shortcuts allow quick editing directly from the board.
 Tasks can also be selected with a rectangle and grouped into collapsible boxes.
-You can pan the board itself by dragging with the middle mouse button or holding `Ctrl` while left-clicking on empty space.
+You can pan the board itself by dragging with the middle mouse button or holding `Ctrl` while left-clicking on empty space. Hold `Ctrl` (or `Cmd` on macOS) and scroll the mouse wheel or press `+`/`-` to zoom the board.
 
 Edges support different relationship types: dependency, subtask and sequence. Click an edge to cycle through these types and the line style will update accordingly.
 

--- a/styles.css
+++ b/styles.css
@@ -4,7 +4,7 @@
   height: 100%;
   background-image: radial-gradient(var(--background-modifier-border) 1px, transparent 0);
   background-size: 20px 20px;
-  transform: translate(0, 0);
+  transform: translate(0, 0) scale(1);
 }
 
 .vtasks-align-line {


### PR DESCRIPTION
## Summary
- support zoom level in `BoardView` with mouse wheel and `+`/`-` shortcuts
- clamp zoom and re-draw edges based on zoom level
- adjust event coordinate calculations to handle zoom
- update default board transform in CSS
- document zoom usage in `README`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68878053fd508331a63696fc561510ed