### PR TITLE
Add interactive minimap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This experimental Obsidian plugin lets you manage markdown tasks on an interacti
 All tasks in your vault are parsed and shown as draggable nodes. Positions and connections are stored in `*.vtasks.json` files next to your notes. Nodes can be moved with the mouse, dependencies are drawn as lines and several keyboard shortcuts allow quick editing directly from the board.
 Tasks can also be selected with a rectangle and grouped into collapsible boxes.
 You can pan the board itself by dragging with the middle mouse button or holding `Ctrl` while left-clicking on empty space. Hold `Ctrl` (or `Cmd` on macOS) and scroll the mouse wheel or press `+`/`-` to zoom the board.
+A minimap in the bottom-right shows an overview of all nodes. Click or drag inside the minimap to quickly pan the board.
 
 Edges support different relationship types: dependency, subtask and sequence. Click an edge to cycle through these types and the line style will update accordingly.
 

--- a/styles.css
+++ b/styles.css
@@ -230,3 +230,37 @@
 .vtasks-node.done {
   outline: 2px solid var(--color-green);
 }
+
+.vtasks-minimap {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  width: 200px;
+  height: 150px;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  overflow: hidden;
+}
+
+.vtasks-minimap svg {
+  width: 100%;
+  height: 100%;
+}
+
+.vtasks-mini-node {
+  fill: var(--background-modifier-border);
+  stroke: var(--text-muted);
+  stroke-width: 0.5;
+}
+
+.vtasks-mini-edge {
+  stroke: var(--text-muted);
+  stroke-width: 0.5;
+  fill: none;
+}
+
+.vtasks-mini-view {
+  position: absolute;
+  border: 1px solid var(--color-accent);
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add interactive minimap to view
- implement minimap drawing and viewport controls
- style the minimap
- document minimap controls in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688783a0c0388331bb7ceeb199486a13