### PR TITLE
Handle existing board files gracefully

### DIFF
--- a/src/boardStore.ts
+++ b/src/boardStore.ts
@@ -38,7 +38,18 @@ export async function getBoardFile(app: App, path: string): Promise<TFile> {
   const normalized = normalizePath(path);
   let file = app.vault.getAbstractFileByPath(normalized) as TFile;
   if (!file) {
-    await app.vault.create(normalized, JSON.stringify({ version: CURRENT_VERSION, nodes: {}, edges: [] }, null, 2));
+    try {
+      await app.vault.create(
+        normalized,
+        JSON.stringify({ version: CURRENT_VERSION, nodes: {}, edges: [] }, null, 2)
+      );
+    } catch (err: any) {
+      if (err?.message?.includes('already exists')) {
+        console.warn(`Board file ${normalized} already exists, loading it`);
+      } else {
+        throw err;
+      }
+    }
     file = app.vault.getAbstractFileByPath(normalized) as TFile;
   }
   return file;


### PR DESCRIPTION
## Summary
- handle "File already exists" when creating board files

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688789c30c888331a102f28403ffa0da