### PR TITLE
Rename plugin to MindTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Visual Tasks Board
+# MindTask
 
-This experimental Obsidian plugin lets you manage markdown tasks on an interactive board.
+MindTask is an experimental Obsidian plugin that lets you manage markdown tasks on an interactive board.
 
 All tasks in your vault are parsed and shown as draggable nodes. Positions and connections are stored in `*.vtasks.json` files next to your notes. Nodes can be moved with the mouse, dependencies are drawn as lines and several keyboard shortcuts allow quick editing directly from the board.
 Tasks can also be selected with a rectangle and grouped into collapsible boxes.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "id": "visual-tasks-board",
-  "name": "Visual Tasks Board",
+  "id": "mind-task",
+  "name": "MindTask",
   "version": "0.0.1",
   "minAppVersion": "1.0.0",
   "description": "Visualize and manage tasks on an interactive board",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "visual-tasks-board",
+  "name": "mind-task",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "visual-tasks-board",
+      "name": "mind-task",
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "visual-tasks-board",
+  "name": "mind-task",
   "version": "0.0.1",
   "description": "Obsidian plugin to visualize tasks on a board",
   "main": "dist/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { scanFiles, parseDependencies, ParsedTask, ScanOptions } from './parser'
 import Controller from './controller';
 import { PluginSettings, DEFAULT_SETTINGS, SettingsTab } from './settings';
 
-export default class VisualTasksPlugin extends Plugin {
+export default class MindTaskPlugin extends Plugin {
   private board: BoardData | null = null;
   private boardFile: TFile | null = null;
   private tasks: Map<string, ParsedTask> = new Map();
@@ -37,7 +37,7 @@ export default class VisualTasksPlugin extends Plugin {
 
     this.addCommand({
       id: 'open-board',
-      name: 'Open Tasks Board',
+      name: 'Open MindTask Board',
       callback: () => this.openBoard(),
     });
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting } from 'obsidian';
-import VisualTasksPlugin from './main';
+import MindTaskPlugin from './main';
 
 export interface PluginSettings {
   boardFilePath: string;
@@ -16,7 +16,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
 };
 
 export class SettingsTab extends PluginSettingTab {
-  constructor(app: App, private plugin: VisualTasksPlugin) {
+  constructor(app: App, private plugin: MindTaskPlugin) {
     super(app, plugin);
   }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -3,7 +3,7 @@ import Controller from './controller';
 import { BoardData } from './boardStore';
 import { ParsedTask } from './parser';
 
-export const VIEW_TYPE_BOARD = 'visual-tasks-board';
+export const VIEW_TYPE_BOARD = 'mind-task';
 
 export class BoardView extends ItemView {
   private boardEl!: HTMLElement;
@@ -70,7 +70,7 @@ export class BoardView extends ItemView {
   }
 
   getDisplayText() {
-    return 'Tasks Board';
+    return 'MindTask Board';
   }
 
   async onOpen() {


### PR DESCRIPTION
## Summary
- rename plugin to "MindTask"
- update manifest.json, package files and code references
- adjust command and view texts

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887ae369dac8331a54179856deb0f20