### PR TITLE
Add option to use dataview IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,19 @@ Load `manifest.json`, `main.js`, and `styles.css` from the `dist` folder into Ob
 
 ## Structure
 
-- `src/parser.ts` – reads tasks from markdown files and ensures they have block IDs
+- `src/parser.ts` – reads tasks from markdown files and ensures they have unique IDs
 - `src/boardStore.ts` – saves and loads board state
 - `src/controller.ts` – high level actions like creating tasks and edges
 - `src/view.ts` – basic SVG board rendering
 - `src/main.ts` – plugin entry point
 
 This is an early prototype and not feature complete.
+
+## Settings
+
+MindTask can store task identifiers either as block anchors or as dataview
+inline fields. The default **Use block IDs** option appends `^id` at the end of
+each task. When disabled, new tasks receive `[id:: id]` instead.
 
 ## License
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -41,7 +41,10 @@ export default class Controller {
       file = await this.app.vault.create(path, '');
     }
     const id = 't-' + crypto.randomBytes(4).toString('hex');
-    await this.app.vault.append(file, `- [ ] ${text} ^${id}\n`);
+    const idPart = this.settings.useBlockId
+      ? `^${id}`
+      : `[id:: ${id}]`;
+    await this.app.vault.append(file, `- [ ] ${text} ${idPart}\n`);
     const content = await this.app.vault.read(file);
     const line = content.split(/\r?\n/).length - 1;
     const task: ParsedTask = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,7 @@ export default class MindTaskPlugin extends Plugin {
     const parsed = await scanFiles(this.app, files, {
       tags: this.settings.tagFilters,
       folders: this.settings.folderPaths,
+      useBlockId: this.settings.useBlockId,
     });
     const deps = parseDependencies(parsed);
 
@@ -102,6 +103,7 @@ export default class MindTaskPlugin extends Plugin {
     const parsed = await scanFiles(this.app, files, {
       tags: this.settings.tagFilters,
       folders: this.settings.folderPaths,
+      useBlockId: this.settings.useBlockId,
     });
     const deps = parseDependencies(parsed);
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,8 @@ export interface PluginSettings {
   defaultTaskFile: string;
   tagFilters: string[];
   folderPaths: string[];
+  /** Use ^id block anchors rather than [id:: ] inline fields */
+  useBlockId: boolean;
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
@@ -13,6 +15,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   defaultTaskFile: 'Tasks.md',
   tagFilters: [],
   folderPaths: [],
+  useBlockId: true,
 };
 
 export class SettingsTab extends PluginSettingTab {
@@ -78,6 +81,18 @@ export class SettingsTab extends PluginSettingTab {
               .split(',')
               .map((v) => v.trim())
               .filter((v) => v.length > 0);
+            await this.plugin.saveData(this.plugin.settings);
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Use block IDs')
+      .setDesc('Add tasks with ^id anchors instead of [id::] fields')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.useBlockId)
+          .onChange(async (value) => {
+            this.plugin.settings.useBlockId = value;
             await this.plugin.saveData(this.plugin.settings);
           })
       );


### PR DESCRIPTION
## Summary
- add `useBlockId` setting with UI toggle
- insert either `^id` or `[id:: id]` when scanning or creating tasks
- propagate new option to `scanFiles`
- document the new setting in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688872b1d3c88331b989fb781f155741