### PR TITLE
Switch to Dataview metadata for relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ A minimap in the bottom-right shows an overview of all nodes. Click or drag insi
 
 Edges support different relationship types: dependency, subtask and sequence. Click an edge to cycle through these types and the line style will update accordingly.
 
+Task relationships are stored using Dataview inline fields referencing the target task's ID:
+
+- `[dependsOn:: id]` – the current task depends on another
+- `[subtaskOf:: id]` – the current task is a subtask
+- `[after:: id]` – the current task should come after another
+
 ## Development
 
 Install dependencies and build the plugin:

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -145,14 +145,13 @@ export default class Controller {
   }
 
   private relationString(type: string, from: ParsedTask, to: ParsedTask) {
-    const target = `[[${to.file.path}#^${to.blockId}]]`;
     switch (type) {
       case 'depends':
-        return `dependsOn:: ${target}`;
+        return `[dependsOn:: ${to.blockId}]`;
       case 'subtask':
-        return `subtaskOf:: ${target}`;
+        return `[subtaskOf:: ${to.blockId}]`;
       case 'sequence':
-        return `after:: ${target}`;
+        return `[after:: ${to.blockId}]`;
       default:
         return '';
     }
@@ -163,6 +162,10 @@ export default class Controller {
     if (!rel) return;
     const insertRel = (t: string) => {
       if (t.includes(rel)) return t;
+      const dv = t.match(/\[id::\s*([\w-]+)\]/);
+      if (dv) {
+        return t.replace(/\[id::\s*([\w-]+)\]/, `${rel} [id:: $1]`);
+      }
       const match = t.match(/\^([\w-]+)$/);
       if (match) {
         return t.replace(/\^([\w-]+)$/, `${rel} ^$1`);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -71,19 +71,19 @@ export async function scanFiles(
  */
 export function parseDependencies(tasks: ParsedTask[]): { from: string; to: string; type: string }[] {
   const edges: { from: string; to: string; type: string }[] = [];
-  const depRegex = /dependsOn::\s*\[\[(.+?)#\^(\w+)\]\]/g;
-  const subtaskRegex = /subtaskOf::\s*\[\[(.+?)#\^(\w+)\]\]/g;
-  const seqRegex = /after::\s*\[\[(.+?)#\^(\w+)\]\]/g;
+  const depRegex = /\[dependsOn::\s*([\w-]+)\]/g;
+  const subtaskRegex = /\[subtaskOf::\s*([\w-]+)\]/g;
+  const seqRegex = /\[after::\s*([\w-]+)\]/g;
   for (const t of tasks) {
     let m: RegExpExecArray | null;
     while ((m = depRegex.exec(t.text)) !== null) {
-      edges.push({ from: m[2], to: t.blockId, type: 'depends' });
+      edges.push({ from: m[1], to: t.blockId, type: 'depends' });
     }
     while ((m = subtaskRegex.exec(t.text)) !== null) {
-      edges.push({ from: m[2], to: t.blockId, type: 'subtask' });
+      edges.push({ from: m[1], to: t.blockId, type: 'subtask' });
     }
     while ((m = seqRegex.exec(t.text)) !== null) {
-      edges.push({ from: m[2], to: t.blockId, type: 'sequence' });
+      edges.push({ from: m[1], to: t.blockId, type: 'sequence' });
     }
   }
   return edges;


### PR DESCRIPTION
## Summary
- parse dependency relations from Dataview inline fields
- generate `[dependsOn:: id]`, `[subtaskOf:: id]` and `[after:: id]`
- insert relations around existing `[id::]` fields when editing
- document Dataview relation format in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68886fa220fc8331907de39adc0e0730