### PR TITLE
Fix relation string direction

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -147,11 +147,11 @@ export default class Controller {
   private relationString(type: string, from: ParsedTask, to: ParsedTask) {
     switch (type) {
       case 'depends':
-        return `[dependsOn:: ${to.blockId}]`;
+        return `[dependsOn:: ${from.blockId}]`;
       case 'subtask':
-        return `[subtaskOf:: ${to.blockId}]`;
+        return `[subtaskOf:: ${from.blockId}]`;
       case 'sequence':
-        return `[after:: ${to.blockId}]`;
+        return `[after:: ${from.blockId}]`;
       default:
         return '';
     }


### PR DESCRIPTION
## Summary
- correct relationString to use the source task ID

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888914e4f988331af4830bbac7b2017