### PR TITLE
Improve board UX with infinite background

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -11,6 +11,7 @@ export class BoardView extends ItemView {
   private alignVLine!: HTMLElement;
   private alignHLine!: HTMLElement;
   private readonly gridSize = 20;
+  private readonly boardSize = 50000;
   private selectedIds: Set<string> = new Set();
   private draggingId: string | null = null;
   private dragOffsetX = 0;
@@ -122,7 +123,10 @@ export class BoardView extends ItemView {
       backBtn.onclick = () => this.openGroup(this.board.nodes[this.groupId!].group || null);
     }
 
-    this.boardEl = this.containerEl.createDiv('vtasks-board');
+    const wrapper = this.containerEl.createDiv('vtasks-board-wrapper');
+    this.boardEl = wrapper.createDiv('vtasks-board');
+    this.boardEl.style.width = `${this.boardSize}px`;
+    this.boardEl.style.height = `${this.boardSize}px`;
     this.boardEl.tabIndex = 0;
     this.boardEl.style.transform = `translate(${this.boardOffsetX}px, ${this.boardOffsetY}px) scale(${this.zoom})`;
     this.alignVLine = this.boardEl.createDiv('vtasks-align-line vtasks-align-v');
@@ -694,18 +698,8 @@ export class BoardView extends ItemView {
 
   private updateBoardSize() {
     if (!this.boardEl) return;
-    let maxX = 0;
-    let maxY = 0;
-    for (const id in this.board.nodes) {
-      const n = this.board.nodes[id];
-      if ((n.group || null) !== this.groupId) continue;
-      const w = n.width ?? 120;
-      const h = n.height ?? (n.type === 'group' ? 80 : 40);
-      maxX = Math.max(maxX, n.x + w);
-      maxY = Math.max(maxY, n.y + h);
-    }
-    this.boardEl.style.width = maxX + 'px';
-    this.boardEl.style.height = maxY + 'px';
+    this.boardEl.style.width = `${this.boardSize}px`;
+    this.boardEl.style.height = `${this.boardSize}px`;
   }
 
   private openGroup(id: string | null) {

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,14 @@
-.vtasks-board {
+.vtasks-board-wrapper {
   position: relative;
   width: 100%;
   height: 100%;
+  overflow: hidden;
+}
+
+.vtasks-board {
+  position: absolute;
+  top: 0;
+  left: 0;
   background-image: radial-gradient(var(--background-modifier-border) 1px, transparent 0);
   background-size: 20px 20px;
   transform: translate(0, 0) scale(1);


### PR DESCRIPTION
## Summary
- wrap the board element so we can hide overflow
- make the board position absolute and very large for panning
- remove automatic sizing for a virtual infinite board

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688893953d008331b856429147c00813