### PR TITLE
Fix minimap bounds

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -40,6 +40,8 @@ export class BoardView extends ItemView {
   private minimapScale = 1;
   private minimapOffsetX = 0;
   private minimapOffsetY = 0;
+  private contentWidth = 0;
+  private contentHeight = 0;
   private isMinimapDragging = false;
   private resizingId: string | null = null;
   private resizeDir = '';
@@ -735,6 +737,8 @@ export class BoardView extends ItemView {
     maxY += pad;
     const bw = maxX - minX;
     const bh = maxY - minY;
+    this.contentWidth = bw;
+    this.contentHeight = bh;
     const mw = this.minimapEl.clientWidth;
     const mh = this.minimapEl.clientHeight;
     const scale = Math.min(mw / bw, mh / bh);
@@ -776,8 +780,8 @@ export class BoardView extends ItemView {
     if (!this.minimapView) return;
     const x = (-this.boardOffsetX / this.zoom - this.minimapOffsetX) * this.minimapScale;
     const y = (-this.boardOffsetY / this.zoom - this.minimapOffsetY) * this.minimapScale;
-    const w = (this.boardEl.offsetWidth / this.zoom) * this.minimapScale;
-    const h = (this.boardEl.offsetHeight / this.zoom) * this.minimapScale;
+    const w = (this.contentWidth || this.boardEl.offsetWidth) / this.zoom * this.minimapScale;
+    const h = (this.contentHeight || this.boardEl.offsetHeight) / this.zoom * this.minimapScale;
     this.minimapView.style.left = x + 'px';
     this.minimapView.style.top = y + 'px';
     this.minimapView.style.width = w + 'px';
@@ -790,8 +794,10 @@ export class BoardView extends ItemView {
     const y = e.clientY - rect.top;
     const bx = x / this.minimapScale + this.minimapOffsetX;
     const by = y / this.minimapScale + this.minimapOffsetY;
-    this.boardOffsetX = this.boardEl.offsetWidth / 2 - bx * this.zoom;
-    this.boardOffsetY = this.boardEl.offsetHeight / 2 - by * this.zoom;
+    const boardW = this.contentWidth || this.boardEl.offsetWidth;
+    const boardH = this.contentHeight || this.boardEl.offsetHeight;
+    this.boardOffsetX = boardW / 2 - bx * this.zoom;
+    this.boardOffsetY = boardH / 2 - by * this.zoom;
     this.boardEl.style.transform = `translate(${this.boardOffsetX}px, ${this.boardOffsetY}px) scale(${this.zoom})`;
     this.updateMinimapView();
     this.drawEdges();


### PR DESCRIPTION
## Summary
- track true board content dimensions
- use content dimensions to draw and move minimap view

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68889aaea1c48331937bd8c42954c0b4