### PR TITLE
Fix minimap and board interactions

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -41,6 +41,8 @@ export class BoardView extends ItemView {
   private minimapOffsetX = 0;
   private minimapOffsetY = 0;
   private isMinimapDragging = false;
+  private contentWidth = 0;
+  private contentHeight = 0;
   private resizingId: string | null = null;
   private resizeDir = '';
   private resizeStartWidth = 0;
@@ -735,6 +737,8 @@ export class BoardView extends ItemView {
     maxY += pad;
     const bw = maxX - minX;
     const bh = maxY - minY;
+    this.contentWidth = bw;
+    this.contentHeight = bh;
     const mw = this.minimapEl.clientWidth;
     const mh = this.minimapEl.clientHeight;
     const scale = Math.min(mw / bw, mh / bh);
@@ -776,8 +780,10 @@ export class BoardView extends ItemView {
     if (!this.minimapView) return;
     const x = (-this.boardOffsetX / this.zoom - this.minimapOffsetX) * this.minimapScale;
     const y = (-this.boardOffsetY / this.zoom - this.minimapOffsetY) * this.minimapScale;
-    const w = (this.boardEl.offsetWidth / this.zoom) * this.minimapScale;
-    const h = (this.boardEl.offsetHeight / this.zoom) * this.minimapScale;
+    const cw = this.contentWidth || this.boardEl.offsetWidth;
+    const ch = this.contentHeight || this.boardEl.offsetHeight;
+    const w = (cw / this.zoom) * this.minimapScale;
+    const h = (ch / this.zoom) * this.minimapScale;
     this.minimapView.style.left = x + 'px';
     this.minimapView.style.top = y + 'px';
     this.minimapView.style.width = w + 'px';
@@ -790,8 +796,10 @@ export class BoardView extends ItemView {
     const y = e.clientY - rect.top;
     const bx = x / this.minimapScale + this.minimapOffsetX;
     const by = y / this.minimapScale + this.minimapOffsetY;
-    this.boardOffsetX = this.boardEl.offsetWidth / 2 - bx * this.zoom;
-    this.boardOffsetY = this.boardEl.offsetHeight / 2 - by * this.zoom;
+    const cw = this.contentWidth || this.boardEl.offsetWidth;
+    const ch = this.contentHeight || this.boardEl.offsetHeight;
+    this.boardOffsetX = cw / 2 - bx * this.zoom;
+    this.boardOffsetY = ch / 2 - by * this.zoom;
     this.boardEl.style.transform = `translate(${this.boardOffsetX}px, ${this.boardOffsetY}px) scale(${this.zoom})`;
     this.updateMinimapView();
     this.drawEdges();

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,7 @@
   background-image: radial-gradient(var(--background-modifier-border) 1px, transparent 0);
   background-size: 20px 20px;
   transform: translate(0, 0) scale(1);
+  transform-origin: 0 0;
 }
 
 .vtasks-align-line {


### PR DESCRIPTION
## Summary
- track actual board content size for minimap
- use content dimensions when updating and moving from minimap
- set transform origin so board translation works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688898b9e10c83319511ef2977517099