### PR TITLE
Implement infinite board

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -32,6 +32,7 @@ export class BoardView extends ItemView {
   private boardStartY = 0;
   private boardOffsetX = 0;
   private boardOffsetY = 0;
+  private boardPadding = 10000;
   private zoom = 1;
   private minimapEl!: HTMLElement;
   private minimapSvg!: SVGSVGElement;
@@ -124,6 +125,10 @@ export class BoardView extends ItemView {
 
     this.boardEl = this.containerEl.createDiv('vtasks-board');
     this.boardEl.tabIndex = 0;
+    if (this.boardOffsetX === 0 && this.boardOffsetY === 0) {
+      this.boardOffsetX = this.containerEl.clientWidth / 2 - this.boardPadding;
+      this.boardOffsetY = this.containerEl.clientHeight / 2 - this.boardPadding;
+    }
     this.boardEl.style.transform = `translate(${this.boardOffsetX}px, ${this.boardOffsetY}px) scale(${this.zoom})`;
     this.alignVLine = this.boardEl.createDiv('vtasks-align-line vtasks-align-v');
     this.alignHLine = this.boardEl.createDiv('vtasks-align-line vtasks-align-h');
@@ -158,8 +163,8 @@ export class BoardView extends ItemView {
     const pos = this.board.nodes[id];
     const nodeEl = this.boardEl.createDiv('vtasks-node');
     nodeEl.setAttr('data-id', id);
-    nodeEl.style.left = pos.x + 'px';
-    nodeEl.style.top = pos.y + 'px';
+    nodeEl.style.left = pos.x + this.boardPadding + 'px';
+    nodeEl.style.top = pos.y + this.boardPadding + 'px';
     if (pos.width) nodeEl.style.width = pos.width + 'px';
     if (pos.height) nodeEl.style.height = pos.height + 'px';
     if (pos.color) nodeEl.style.borderColor = pos.color;
@@ -292,8 +297,8 @@ export class BoardView extends ItemView {
         this.selStartX = coords.x;
         this.selStartY = coords.y;
         this.selectionRect = this.boardEl.createDiv('vtasks-selection');
-        this.selectionRect.style.left = this.selStartX + 'px';
-        this.selectionRect.style.top = this.selStartY + 'px';
+        this.selectionRect.style.left = this.selStartX + this.boardPadding + 'px';
+        this.selectionRect.style.top = this.selStartY + this.boardPadding + 'px';
       }
     };
 
@@ -321,8 +326,8 @@ export class BoardView extends ItemView {
         height = Math.max(20, height);
         nodeEl.style.width = width + 'px';
         nodeEl.style.height = height + 'px';
-        nodeEl.style.left = x + 'px';
-        nodeEl.style.top = y + 'px';
+        nodeEl.style.left = x + this.boardPadding + 'px';
+        nodeEl.style.top = y + this.boardPadding + 'px';
         this.board.nodes[id] = { ...this.board.nodes[id], x, y, width, height };
         this.updateOverflow(nodeEl);
         this.updateBoardSize();
@@ -342,9 +347,9 @@ export class BoardView extends ItemView {
           let y = start.y + dy;
 
           const nodeEl = this.boardEl.querySelector(`.vtasks-node[data-id="${id}"]`) as HTMLElement;
-          nodeEl.style.left = x + 'px';
-          nodeEl.style.top = y + 'px';
-        this.board.nodes[id] = { ...this.board.nodes[id], x, y };
+          nodeEl.style.left = x + this.boardPadding + 'px';
+          nodeEl.style.top = y + this.boardPadding + 'px';
+          this.board.nodes[id] = { ...this.board.nodes[id], x, y };
       });
       this.updateBoardSize();
       this.drawEdges();
@@ -368,8 +373,8 @@ export class BoardView extends ItemView {
         const top = Math.min(this.selStartY, y);
         const width = Math.abs(x - this.selStartX);
         const height = Math.abs(y - this.selStartY);
-        this.selectionRect.style.left = left + 'px';
-        this.selectionRect.style.top = top + 'px';
+        this.selectionRect.style.left = left + this.boardPadding + 'px';
+        this.selectionRect.style.top = top + this.boardPadding + 'px';
         this.selectionRect.style.width = width + 'px';
         this.selectionRect.style.height = height + 'px';
       }
@@ -694,18 +699,10 @@ export class BoardView extends ItemView {
 
   private updateBoardSize() {
     if (!this.boardEl) return;
-    let maxX = 0;
-    let maxY = 0;
-    for (const id in this.board.nodes) {
-      const n = this.board.nodes[id];
-      if ((n.group || null) !== this.groupId) continue;
-      const w = n.width ?? 120;
-      const h = n.height ?? (n.type === 'group' ? 80 : 40);
-      maxX = Math.max(maxX, n.x + w);
-      maxY = Math.max(maxY, n.y + h);
-    }
-    this.boardEl.style.width = maxX + 'px';
-    this.boardEl.style.height = maxY + 'px';
+    // Keep the board extremely large so users never see an edge
+    const size = this.boardPadding * 2;
+    this.boardEl.style.width = `${size}px`;
+    this.boardEl.style.height = `${size}px`;
   }
 
   private openGroup(id: string | null) {
@@ -782,8 +779,8 @@ export class BoardView extends ItemView {
     if (!this.minimapView) return;
     const x = (-this.boardOffsetX / this.zoom - this.minimapOffsetX) * this.minimapScale;
     const y = (-this.boardOffsetY / this.zoom - this.minimapOffsetY) * this.minimapScale;
-    const w = (this.boardEl.offsetWidth / this.zoom) * this.minimapScale;
-    const h = (this.boardEl.offsetHeight / this.zoom) * this.minimapScale;
+    const w = (this.containerEl.clientWidth / this.zoom) * this.minimapScale;
+    const h = (this.containerEl.clientHeight / this.zoom) * this.minimapScale;
     this.minimapView.style.left = x + 'px';
     this.minimapView.style.top = y + 'px';
     this.minimapView.style.width = w + 'px';
@@ -796,8 +793,8 @@ export class BoardView extends ItemView {
     const y = e.clientY - rect.top;
     const bx = x / this.minimapScale + this.minimapOffsetX;
     const by = y / this.minimapScale + this.minimapOffsetY;
-    this.boardOffsetX = this.boardEl.offsetWidth / 2 - bx * this.zoom;
-    this.boardOffsetY = this.boardEl.offsetHeight / 2 - by * this.zoom;
+    this.boardOffsetX = this.containerEl.clientWidth / 2 - bx * this.zoom;
+    this.boardOffsetY = this.containerEl.clientHeight / 2 - by * this.zoom;
     this.boardEl.style.transform = `translate(${this.boardOffsetX}px, ${this.boardOffsetY}px) scale(${this.zoom})`;
     this.updateMinimapView();
     this.drawEdges();
@@ -806,8 +803,8 @@ export class BoardView extends ItemView {
   private getBoardCoords(e: MouseEvent | PointerEvent) {
     const rect = this.boardEl.getBoundingClientRect();
     return {
-      x: (e.clientX - rect.left) / this.zoom,
-      y: (e.clientY - rect.top) / this.zoom,
+      x: (e.clientX - rect.left) / this.zoom - this.boardPadding,
+      y: (e.clientY - rect.top) / this.zoom - this.boardPadding,
     };
   }
 }


### PR DESCRIPTION
## Summary
- keep board extremely large and add padding so it's effectively infinite in every direction
- center board on first render and offset node positions by the padding

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a0e4bef848331b68067befa97c375