### PR TITLE
Expand board area for unlimited panning

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -90,6 +90,7 @@ export class BoardView extends ItemView {
 
   private render() {
     this.containerEl.empty();
+    this.containerEl.addClass('vtasks-container');
     const controls = this.containerEl.createDiv('vtasks-filter-bar');
     const tagInput = controls.createEl('input', {
       type: 'text',

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,14 @@
+.vtasks-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
 .vtasks-board {
   position: relative;
-  width: 100vw;
-  height: 100vh;
+  width: 100000px;
+  height: 100000px;
   overflow: visible;
   background-image: radial-gradient(var(--background-modifier-border) 1px, transparent 0);
   background-size: 20px 20px;


### PR DESCRIPTION
## Summary
- allow the view container to scroll by giving it its own class
- massively enlarge `.vtasks-board` so pointer events work outside the viewport

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a37676cfc83318a0c600d7117ee4b