### PR TITLE
Support multiple boards

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -590,7 +590,7 @@ export class BoardView extends ItemView {
       this.moveBoardFromMinimap(e as PointerEvent);
     };
     this.minimapEl.onpointermove = (e) => {
-      if this.isMinimapDragging) this.moveBoardFromMinimap(e as PointerEvent);
+      if (this.isMinimapDragging) this.moveBoardFromMinimap(e as PointerEvent);
     };
     this.minimapEl.onpointerup = () => {
       this.isMinimapDragging = false;


### PR DESCRIPTION
## Summary
- store boards in plugin data using a new `BoardInfo` interface
- add UI to manage a list of boards in settings
- prompt user to select/create a board when opening
- refresh only the active board on vault changes
- minor fix in `view.ts`

## Testing
- `npm install`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a48f31afc833195732549aace9b5a