### PR TITLE
Add 'Add existing task' context menu

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -62,6 +62,12 @@ export default class Controller {
     return id;
   }
 
+  async addExistingTask(id: string, x: number, y: number) {
+    if (!this.tasks.has(id)) return;
+    this.board.nodes[id] = { x, y } as NodeData;
+    await saveBoard(this.app, this.boardFile, this.board);
+  }
+
   async openTask(id: string) {
     const task = this.tasks.get(id);
     if (!task) return;


### PR DESCRIPTION
## Summary
- add `addExistingTask` method to controller
- support adding an existing task from the board context menu
- implement `openExistingTaskModal` in board view

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b1ed5c08c83319a42259c47f87208