### PR TITLE
Enable board data loading on file open

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,22 @@ export default class MindTaskPlugin extends Plugin {
         (tags, folders) => this.updateFilters(tags, folders)
       )
     );
+    this.registerExtensions(['vtasks.json'], VIEW_TYPE_BOARD);
+
+    this.registerEvent(
+      this.app.workspace.on('file-open', async (file) => {
+        if (!file || !file.path.endsWith('.vtasks.json')) return;
+        this.activeBoard = { name: file.basename, path: file.path };
+        await this.loadBoardData(file.path);
+        const view = this.app.workspace.getActiveViewOfType(BoardView);
+        if (view) {
+          view.updateData(this.board!, this.tasks, {
+            tags: this.settings.tagFilters,
+            folders: this.settings.folderPaths,
+          });
+        }
+      })
+    );
 
     const onVaultChange = (file: TAbstractFile) => {
       if (!this.boardFile) return;


### PR DESCRIPTION
## Summary
- support opening `vtasks.json` files directly
- load board data when a board file is opened in Obsidian

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b38bc92048331814afc4818fc8ef8