### PR TITLE
Auto create board folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ MindTask can store task identifiers either as block anchors or as dataview
 inline fields. The default **Use block IDs** option appends `^id` at the end of
 each task. When disabled, new tasks receive `[id:: id]` instead.
 
+When creating a new board you can choose where the `.vtasks.json` file is saved.
+If the selected path includes folders that do not exist, MindTask will create
+those folders automatically before writing the board file.
+
 ## License
 
 Distributed under the MIT License. See [LICENSE](LICENSE) for more information.

--- a/src/boardStore.ts
+++ b/src/boardStore.ts
@@ -38,6 +38,18 @@ export async function getBoardFile(app: App, path: string): Promise<TFile> {
   const normalized = normalizePath(path);
   let file = app.vault.getAbstractFileByPath(normalized) as TFile;
   if (!file) {
+    const dir = normalized.split('/').slice(0, -1).join('/');
+    if (dir) {
+      const parts = dir.split('/');
+      let cur = '';
+      for (const part of parts) {
+        cur = cur ? `${cur}/${part}` : part;
+        if (!app.vault.getAbstractFileByPath(cur)) {
+          await app.vault.createFolder(cur);
+        }
+      }
+    }
+
     try {
       await app.vault.create(
         normalized,


### PR DESCRIPTION
## Summary
- automatically create parent folders when creating board files
- document automatic board folder creation

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b5666cba483318b62ce9c37ddc2c6