### PR TITLE
Ensure board files open in plugin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,8 +27,8 @@ export default class MindTaskPlugin extends Plugin {
     this.registerView(VIEW_TYPE_BOARD, (leaf) =>
       new BoardView(
         leaf,
-        this.controller!,
-        this.board!,
+        this.controller,
+        this.board,
         this.tasks,
         { tags: this.settings.tagFilters, folders: this.settings.folderPaths },
         (tags, folders) => this.updateFilters(tags, folders)
@@ -42,8 +42,8 @@ export default class MindTaskPlugin extends Plugin {
         this.activeBoard = { name: file.basename, path: file.path };
         await this.loadBoardData(file.path);
         const view = this.app.workspace.getActiveViewOfType(BoardView);
-        if (view) {
-          view.updateData(this.board!, this.tasks, {
+        if (view && this.board && this.controller) {
+          view.updateData(this.board, this.tasks, this.controller, {
             tags: this.settings.tagFilters,
             folders: this.settings.folderPaths,
           });
@@ -168,8 +168,8 @@ export default class MindTaskPlugin extends Plugin {
     await saveBoard(this.app, this.boardFile, this.board);
 
     const leaf = this.app.workspace.getLeavesOfType(VIEW_TYPE_BOARD)[0];
-    if (leaf) {
-      (leaf.view as BoardView).updateData(this.board, this.tasks, {
+    if (leaf && this.controller) {
+      (leaf.view as BoardView).updateData(this.board, this.tasks, this.controller, {
         tags: this.settings.tagFilters,
         folders: this.settings.folderPaths,
       });

--- a/src/view.ts
+++ b/src/view.ts
@@ -54,8 +54,8 @@ export class BoardView extends ItemView {
 
   constructor(
     leaf: WorkspaceLeaf,
-    private controller: Controller,
-    private board: BoardData,
+    private controller: Controller | null,
+    private board: BoardData | null,
     private tasks: Map<string, ParsedTask>,
     filters: { tags: string[]; folders: string[] },
     onFilterChange: (tags: string[], folders: string[]) => void
@@ -74,21 +74,26 @@ export class BoardView extends ItemView {
   }
 
   async onOpen() {
-    this.render();
+    if (this.board) {
+      this.render();
+    }
   }
 
   updateData(
     board: BoardData,
     tasks: Map<string, ParsedTask>,
+    controller: Controller,
     filters: { tags: string[]; folders: string[] }
   ) {
     this.board = board;
     this.tasks = tasks;
+    this.controller = controller;
     this.filters = filters;
     this.render();
   }
 
   private render() {
+    if (!this.board) return;
     this.containerEl.empty();
     this.containerEl.addClass('vtasks-container');
     const controls = this.containerEl.createDiv('vtasks-filter-bar');


### PR DESCRIPTION
## Summary
- support constructing `BoardView` without a loaded board
- update board data with controller when board files are opened

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b6531e0a88331a6be0cb97c805f24