### PR TITLE
Improve board file display

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,53 @@ export default class MindTaskPlugin extends Plugin {
   boards: BoardInfo[] = [];
   private activeBoard: BoardInfo | null = null;
   settings: PluginSettings = DEFAULT_SETTINGS;
+  private explorerObserver: MutationObserver | null = null;
+
+  private updateExplorerTitles() {
+    const leaves = this.app.workspace.getLeavesOfType('file-explorer');
+    for (const leaf of leaves) {
+      const root = leaf.view.containerEl;
+      root
+        .querySelectorAll<HTMLElement>(
+          '.nav-file-title[data-path$=".vtasks.json"] .nav-file-title-content'
+        )
+        .forEach((el) => {
+          const title = el.textContent || '';
+          if (!el.dataset.origTitle) {
+            el.dataset.origTitle = title;
+          }
+          const path = (el.parentElement as HTMLElement).getAttribute('data-path') || '';
+          const base = path
+            .split('/')
+            .pop()!
+            .replace(/\.vtasks\.json$/, '');
+          el.textContent = base;
+          el.parentElement?.classList.add('mindtask-file');
+        });
+    }
+  }
+
+  private restoreExplorerTitles() {
+    document
+      .querySelectorAll<HTMLElement>('.nav-file-title-content[data-orig-title]')
+      .forEach((el) => {
+        el.textContent = el.dataset.origTitle!;
+        el.removeAttribute('data-orig-title');
+        el.parentElement?.classList.remove('mindtask-file');
+      });
+  }
+
+  private observeExplorer() {
+    this.updateExplorerTitles();
+    const leaves = this.app.workspace.getLeavesOfType('file-explorer');
+    if (!leaves.length) return;
+    const root = leaves[0].view.containerEl;
+    this.explorerObserver = new MutationObserver(() => this.updateExplorerTitles());
+    this.explorerObserver.observe(root, { childList: true, subtree: true });
+    this.registerEvent(this.app.vault.on('rename', () => this.updateExplorerTitles()));
+    this.registerEvent(this.app.vault.on('create', () => this.updateExplorerTitles()));
+    this.registerEvent(this.app.vault.on('delete', () => this.updateExplorerTitles()));
+  }
 
   async onload() {
     const data = (await this.loadData()) as Partial<PluginData> | null;
@@ -35,6 +82,7 @@ export default class MindTaskPlugin extends Plugin {
       )
     );
     this.registerExtensions(['vtasks.json'], VIEW_TYPE_BOARD);
+    this.observeExplorer();
 
     this.registerEvent(
       this.app.workspace.on('file-open', async (file) => {
@@ -258,5 +306,13 @@ export default class MindTaskPlugin extends Plugin {
       }
       new NewBoardModal(this).open();
     });
+  }
+
+  onunload() {
+    this.restoreExplorerTitles();
+    if (this.explorerObserver) {
+      this.explorerObserver.disconnect();
+      this.explorerObserver = null;
+    }
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -273,3 +273,9 @@
   border: 1px solid var(--color-accent);
   pointer-events: none;
 }
+
+.nav-file-title.mindtask-file .nav-file-title-content::after {
+  content: " (MindTask)";
+  opacity: 0.7;
+  font-size: 0.9em;
+}


### PR DESCRIPTION
## Summary
- add mutation observer to rewrite board file titles in the explorer
- show board name without the extension
- display '(MindTask)' label for board files in the file explorer

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b67291d408331b39954bf87fb1505