### PR TITLE
Disable edge clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tasks can also be selected with a rectangle and grouped into collapsible boxes.
 You can pan the board itself by dragging with the middle mouse button or holding `Ctrl` while left-clicking on empty space. Hold `Ctrl` (or `Cmd` on macOS) and scroll the mouse wheel or press `+`/`-` to zoom the board.
 A minimap in the bottom-right shows an overview of all nodes. Click or drag inside the minimap to quickly pan the board.
 
-Edges support different relationship types: dependency, subtask and sequence. Click an edge to cycle through these types and the line style will update accordingly.
+Edges support different relationship types: dependency, subtask and sequence. Right-click an edge to choose its type or delete the connection from the context menu.
 
 Task relationships are stored using Dataview inline fields referencing the target task's ID:
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -591,18 +591,22 @@ export class BoardView extends ItemView {
       }
     });
 
-    this.svgEl.addEventListener('click', (e) => {
-      const edgeEl = (e.target as HTMLElement).closest('path.vtasks-edge') as SVGPathElement | null;
-      if (edgeEl && edgeEl.getAttr('data-index')) {
-        const idx = parseInt(edgeEl.getAttr('data-index')!);
-        this.controller.cycleEdgeType(idx).then(() => this.render());
-      }
-    });
+    // Left-clicking an edge should no longer change its type. Users now access
+    // edge actions exclusively through the context menu.
+    // this.svgEl.addEventListener('click', (e) => {
+    //   const edgeEl = (e.target as HTMLElement).closest('path.vtasks-edge') as SVGPathElement | null;
+    //   if (edgeEl && edgeEl.getAttr('data-index')) {
+    //     const idx = parseInt(edgeEl.getAttr('data-index')!);
+    //     this.controller.cycleEdgeType(idx).then(() => this.render());
+    //   }
+    // });
 
     this.svgEl.addEventListener('contextmenu', (e) => {
       const edgeEl = (e.target as HTMLElement).closest('path.vtasks-edge') as SVGPathElement | null;
       if (!edgeEl || !edgeEl.getAttr('data-index')) return;
       e.preventDefault();
+      // Prevent the board-level context menu from also opening
+      e.stopPropagation();
       const idx = parseInt(edgeEl.getAttr('data-index')!);
       const edge = this.board.edges[idx];
       if (!edge) return;


### PR DESCRIPTION
## Summary
- disable changing edge types via left-click
- ensure edge context menu stops event propagation
- update docs for new edge handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b75efd4848331923b790f6d3932ad