### PR TITLE
Add customizable task background colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ When creating a new board you can choose where the `.vtasks.json` file is saved.
 If the selected path includes folders that do not exist, MindTask will create
 those folders automatically before writing the board file.
 
+You can also configure which background colors appear in the node context menu
+by entering a comma separated list in the plugin settings.
+
 ## License
 
 Distributed under the MIT License. See [LICENSE](LICENSE) for more information.

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -10,7 +10,7 @@ export default class Controller {
     private boardFile: TFile,
     private board: BoardData,
     private tasks: Map<string, ParsedTask>,
-    private settings: PluginSettings
+    public settings: PluginSettings
   ) {}
 
   async moveNode(id: string, x: number, y: number) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,8 @@ export interface PluginSettings {
   useBlockId: boolean;
   /** Folder to store board files */
   boardFolder: string;
+  /** List of background colors for tasks */
+  backgroundColors: string[];
 }
 
 export interface PluginData {
@@ -27,6 +29,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   folderPaths: [],
   useBlockId: true,
   boardFolder: '',
+  backgroundColors: ['red', 'green', 'blue', 'yellow'],
 };
 
 export class SettingsTab extends PluginSettingTab {
@@ -151,6 +154,22 @@ export class SettingsTab extends PluginSettingTab {
           .setValue(this.plugin.settings.useBlockId)
           .onChange(async (value) => {
             this.plugin.settings.useBlockId = value;
+            await this.plugin.savePluginData();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Background colors')
+      .setDesc('Comma separated list of background colors for tasks')
+      .addText((text) =>
+        text
+          .setPlaceholder('red, green, blue, yellow')
+          .setValue(this.plugin.settings.backgroundColors.join(', '))
+          .onChange(async (value) => {
+            this.plugin.settings.backgroundColors = value
+              .split(',')
+              .map((v) => v.trim())
+              .filter((v) => v.length > 0);
             await this.plugin.savePluginData();
           })
       );

--- a/src/view.ts
+++ b/src/view.ts
@@ -198,7 +198,7 @@ export class BoardView extends ItemView {
     nodeEl.style.top = pos.y + 'px';
     if (pos.width) nodeEl.style.width = pos.width + 'px';
     if (pos.height) nodeEl.style.height = pos.height + 'px';
-    if (pos.color) nodeEl.style.borderColor = pos.color;
+    if (pos.color) nodeEl.style.backgroundColor = pos.color;
 
     const inHandle = nodeEl.createDiv('vtasks-handle vtasks-handle-in');
     const textEl = nodeEl.createDiv('vtasks-text');
@@ -549,15 +549,29 @@ export class BoardView extends ItemView {
           item.setTitle('Ungroup').onClick(() => this.controller.ungroupNode(id).then(() => this.render()))
         );
       }
-      const colors = ['red', 'green', 'blue', 'yellow', ''];
+      const colorMenu = new Menu();
+      const colors = this.controller!.settings.backgroundColors;
       colors.forEach((c) => {
-        const title = c ? `Outline ${c}` : 'Default outline';
-        menu.addItem((item) =>
-          item.setTitle(title).onClick(() => {
-            target.style.borderColor = c ? c : '';
-            this.controller.setNodeColor(id, c || null).then(() => this.render());
-          })
-        );
+        colorMenu.addItem((sub) => {
+          sub.setTitle(c).setIcon('circle');
+          if ((sub as any).iconEl) {
+            ((sub as any).iconEl as HTMLElement).style.color = c;
+          }
+          sub.onClick(() => {
+            target.style.backgroundColor = c;
+            this.controller!.setNodeColor(id, c).then(() => this.render());
+          });
+        });
+      });
+      colorMenu.addItem((sub) =>
+        sub.setTitle('Default').onClick(() => {
+          target.style.backgroundColor = '';
+          this.controller!.setNodeColor(id, null).then(() => this.render());
+        })
+      );
+      menu.addItem((item) => {
+        item.setTitle('Color').setIcon('palette');
+        (item as any).setSubmenu(colorMenu);
       });
       const checked = this.tasks.get(id)?.checked ?? false;
       menu.addItem((item) =>


### PR DESCRIPTION
## Summary
- allow customizing task colors in settings
- show customizable color submenu on node context menu
- switch from outline color to background color
- document background color configuration

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b771601f083319a87d4377bb76c11