### PR TITLE
Fix metadata spacing and inline renaming

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -44,7 +44,7 @@ export default class Controller {
     const idPart = this.settings.useBlockId
       ? `^${id}`
       : `[id:: ${id}]`;
-    await this.app.vault.append(file, `- [ ] ${text} ${idPart}\n`);
+    await this.app.vault.append(file, `- [ ] ${text}  ${idPart}\n`);
     const content = await this.app.vault.read(file);
     const line = content.split(/\r?\n/).length - 1;
     const task: ParsedTask = {
@@ -96,6 +96,17 @@ export default class Controller {
     lines[task.line] = `${indent}- [${checked ? 'x' : ' '}] ${rest}`;
     await this.app.vault.modify(task.file, lines.join('\n'));
     task.checked = checked;
+  }
+
+  async renameTask(id: string, text: string) {
+    const task = this.tasks.get(id);
+    if (!task) return;
+    await this.modifyTaskText(task, (t) => {
+      const metaPart = t.match(/(?:\s+(?:\[[^\]]+\]|#[^\s]+|\^[\w-]+|\w+::\s*(?:\[[^\]]+\]|[^\s]+)))*$/)?.[0] ?? '';
+      const tokens = metaPart.trim().match(/(\[[^\]]+\]|#[^\s]+|\^[\w-]+|\w+::\s*(?:\[[^\]]+\]|[^\s]+))/g) ?? [];
+      const metaFormatted = tokens.join('  ');
+      return text.trim() + (metaFormatted ? `  ${metaFormatted}` : '');
+    });
   }
 
   async setNodeColor(id: string, color: string | null) {
@@ -170,13 +181,13 @@ export default class Controller {
       if (t.includes(rel)) return t;
       const dv = t.match(/\[id::\s*([\w-]+)\]/);
       if (dv) {
-        return t.replace(/\[id::\s*([\w-]+)\]/, `${rel} [id:: $1]`);
+        return t.replace(/\[id::\s*([\w-]+)\]/, `${rel}  [id:: $1]`);
       }
       const match = t.match(/\^([\w-]+)$/);
       if (match) {
-        return t.replace(/\^([\w-]+)$/, `${rel} ^$1`);
+        return t.replace(/\^([\w-]+)$/, `${rel}  ^$1`);
       }
-      return `${t} ${rel}`;
+      return `${t}  ${rel}`;
     };
     await this.modifyTaskText(to, insertRel);
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -51,9 +51,9 @@ export async function scanFiles(
       } else {
         blockId = 't-' + crypto.randomBytes(4).toString('hex');
         if (useBlockId) {
-          lines[i] = lines[i] + ` ^${blockId}`;
+          lines[i] = lines[i] + `  ^${blockId}`;
         } else {
-          lines[i] = lines[i] + ` [id:: ${blockId}]`;
+          lines[i] = lines[i] + `  [id:: ${blockId}]`;
         }
         modified = true;
       }

--- a/styles.css
+++ b/styles.css
@@ -236,6 +236,15 @@
   color: var(--background-primary);
 }
 
+.vtasks-edit-input {
+  width: 100%;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  color: var(--text-normal);
+  padding: 0;
+  margin: 0;
+}
+
 .vtasks-node.done {
   outline: 2px solid var(--color-green);
 }


### PR DESCRIPTION
## Summary
- ensure block IDs and relations are added with double spaces
- avoid leftover `[` when parsing tasks
- allow single–click to rename tasks on the board

## Testing
- `npm test`
- `npm install`
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b7b1f3f8083319d061af24aa925c4