### PR TITLE
Stop board keydown during text editing

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -851,9 +851,12 @@ export class BoardView extends ItemView {
       }
     };
     input.addEventListener('keydown', (e) => {
+      e.stopPropagation();
       if (e.key === 'Enter') {
+        e.preventDefault();
         finish(true);
       } else if (e.key === 'Escape') {
+        e.preventDefault();
         finish(false);
       }
     });


### PR DESCRIPTION
## Summary
- prevent board keydown handler from receiving events while editing text
- allow pressing Enter or Escape to finish editing without board shortcuts firing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b831eebec8331887fc46b5ae9a417