### PR TITLE
Add color labels for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ When creating a new board you can choose where the `.vtasks.json` file is saved.
 If the selected path includes folders that do not exist, MindTask will create
 those folders automatically before writing the board file.
 
-You can also configure which background colors appear in the node context menu
-by entering a comma separated list in the plugin settings.
+You can configure the colors shown in the context menu from the plugin
+settings. Each color can optionally be paired with a label such as `urgent` or
+`priority:: lowest`. When a task contains that tag or metadata field, the node
+is automatically colored.
 
 ## License
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,13 @@ export default class MindTaskPlugin extends Plugin {
     const data = (await this.loadData()) as Partial<PluginData> | null;
     if (data) {
       this.settings = Object.assign({}, DEFAULT_SETTINGS, data.settings);
+      if (
+        Array.isArray((this.settings as any).backgroundColors) &&
+        typeof (this.settings as any).backgroundColors[0] === 'string'
+      ) {
+        this.settings.backgroundColors = ((this.settings as any)
+          .backgroundColors as unknown as string[]).map((c) => ({ color: c }));
+      }
       this.boards = data.boards ?? [];
     } else {
       this.settings = { ...DEFAULT_SETTINGS };

--- a/src/view.ts
+++ b/src/view.ts
@@ -245,6 +245,25 @@ export class BoardView extends ItemView {
           metaEl.createSpan({ text: `${m.key}:${m.val}` });
         }
       });
+      if (!pos.color) {
+        const rules = this.controller?.settings.backgroundColors ?? [];
+        for (const r of rules) {
+          if (!r.label) continue;
+          if (r.label.includes('::')) {
+            const [k, v] = r.label.split('::').map((s) => s.trim());
+            if (metas.some((m) => m.key === k && m.val === v)) {
+              nodeEl.style.backgroundColor = r.color;
+              break;
+            }
+          } else {
+            const lbl = r.label.replace(/^#/, '');
+            if (tags.includes('#' + lbl)) {
+              nodeEl.style.backgroundColor = r.color;
+              break;
+            }
+          }
+        }
+      }
       const tagsEl = metaEl.createDiv('vtasks-tags');
       tags.forEach((t) => tagsEl.createSpan({ text: t, cls: 'vtasks-tag' }));
       if (task?.checked) nodeEl.addClass('done');
@@ -575,13 +594,13 @@ export class BoardView extends ItemView {
       const colors = this.controller!.settings.backgroundColors;
       colors.forEach((c) => {
         colorMenu.addItem((sub) => {
-          sub.setTitle(c).setIcon('circle');
+          sub.setTitle(c.label ? c.label : c.color).setIcon('circle');
           if ((sub as any).iconEl) {
-            ((sub as any).iconEl as HTMLElement).style.color = c;
+            ((sub as any).iconEl as HTMLElement).style.color = c.color;
           }
           sub.onClick(() => {
-            target.style.backgroundColor = c;
-            this.controller!.setNodeColor(id, c).then(() => this.render());
+            target.style.backgroundColor = c.color;
+            this.controller!.setNodeColor(id, c.color).then(() => this.render());
           });
         });
       });


### PR DESCRIPTION
## Summary
- allow assigning labels to background colors in settings
- convert old color lists on load
- apply colors automatically based on task metadata
- update documentation for new color feature

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b832c8e0c833189662bc844bdea81