### PR TITLE
Fix color context menu

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -592,25 +592,6 @@ export class BoardView extends ItemView {
       }
       const colors = this.controller!.settings.backgroundColors;
 
-      colors.forEach((c) => {
-        colorMenu.addItem((sub) => {
-          sub.setTitle(c.label ? c.label : c.color).setIcon('circle');
-          if ((sub as any).iconEl) {
-            ((sub as any).iconEl as HTMLElement).style.color = c.color;
-          }
-          sub.onClick(() => {
-            target.style.backgroundColor = c.color;
-            this.controller!.setNodeColor(id, c.color).then(() => this.render());
-          });
-        });
-      });
-      colorMenu.addItem((sub) =>
-        sub.setTitle('Default').onClick(() => {
-          target.style.backgroundColor = '';
-          this.controller!.setNodeColor(id, null).then(() => this.render());
-        })
-      );
-
       menu.addItem((item) => {
         item.setTitle('Color').setIcon('palette');
         item.setSubmenu((sub) => {


### PR DESCRIPTION
## Summary
- delete stray `colorMenu` setup in BoardView
- rely on submenu builder for node colors

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b868a2eec8331bc757a9a1ee48385