### PR TITLE
Enhance task click actions

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,4 +1,4 @@
-import { App, normalizePath, TFile } from 'obsidian';
+import { App, normalizePath, TFile, MarkdownView } from 'obsidian';
 import crypto from 'crypto';
 import { BoardData, NodeData, saveBoard } from './boardStore';
 import { ParsedTask } from './parser';
@@ -76,6 +76,24 @@ export default class Controller {
       '',
       true
     );
+  }
+
+  async editTask(id: string) {
+    const task = this.tasks.get(id);
+    if (!task) return;
+    await this.app.workspace.openLinkText(
+      `${task.file.path}#^${task.blockId}`,
+      '',
+      false
+    );
+    const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+    if (!view) return;
+    view.editor.setCursor({ line: task.line, ch: 0 });
+    if (this.app.commands.commands['obsidian-tasks-plugin:edit-task']) {
+      await this.app.commands.executeCommandById(
+        'obsidian-tasks-plugin:edit-task'
+      );
+    }
   }
 
   async toggleCheck(id: string) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -292,7 +292,7 @@ export class BoardView extends ItemView {
       if (pos.type === 'group') {
         this.openGroup(id);
       } else {
-        this.controller.openTask(id);
+        this.controller?.editTask(id);
       }
     });
   }
@@ -338,6 +338,10 @@ export class BoardView extends ItemView {
         this.svgEl.appendChild(path);
       } else if (node && !inHandle) {
         const id = node.getAttribute('data-id')!;
+        if ((e as PointerEvent).ctrlKey || (e as PointerEvent).metaKey) {
+          // ctrl-click handled in click event
+          return;
+        }
         this.selectNode(node, id, (e as PointerEvent).shiftKey || (e as PointerEvent).metaKey);
         this.draggingId = id;
         const coords = this.getBoardCoords(e as PointerEvent);
@@ -544,14 +548,11 @@ export class BoardView extends ItemView {
       const target = (e.target as HTMLElement).closest('.vtasks-node') as HTMLElement | null;
       if (target) {
         const id = target.getAttribute('data-id')!;
-        this.selectNode(target, id, (e as MouseEvent).shiftKey || (e as MouseEvent).metaKey);
-        if ((e as MouseEvent).detail === 1) {
-          if (this.editTimer) window.clearTimeout(this.editTimer);
-          this.editTimer = window.setTimeout(() => {
-            if (this.editingId) return;
-            this.startEditing(target, id);
-          }, 200);
+        if ((e as MouseEvent).ctrlKey || (e as MouseEvent).metaKey) {
+          this.controller?.openTask(id);
+          return;
         }
+        this.selectNode(target, id, (e as MouseEvent).shiftKey || (e as MouseEvent).metaKey);
       } else {
         this.finishEditing(true);
         this.clearSelection();


### PR DESCRIPTION
## Summary
- add `editTask()` in controller to open Tasks plugin's edit modal
- modify node dblclick to use `editTask`
- use Ctrl+click to open note for a task
- avoid dragging when Ctrl is held

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b864b93d48331a32ae411e71e26eb