### PR TITLE
Fix color menu and clarify metadata labels

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,7 +8,10 @@ export interface BoardInfo {
 
 export interface ColorOption {
   color: string;
-  /** Optional tag or field label that triggers this color */
+  /**
+   * Optional tag or field label that triggers this color.
+   * Use "#tag" to match a tag or "field:: value" for a metadata field.
+   */
   label?: string;
 }
 
@@ -193,9 +196,12 @@ export class SettingsTab extends PluginSettingTab {
                 await this.plugin.savePluginData();
               })
           )
+          // "Label" accepts either a tag (e.g. "#next") or a field
+          // in the form "status:: done". Tasks containing the label
+          // automatically use this color.
           .addText((text) =>
             text
-              .setPlaceholder('Label (optional)')
+              .setPlaceholder('Label (e.g. #tag or key:: value)')
               .setValue(c.label ?? '')
               .onChange(async (v) => {
                 c.label = v.trim() || undefined;

--- a/src/view.ts
+++ b/src/view.ts
@@ -598,13 +598,16 @@ export class BoardView extends ItemView {
         item.setSubmenu((sub) => {
           colors.forEach((c) => {
             sub.addItem((subItem) => {
-              subItem.setTitle(c).setIcon('circle');
+              const title = c.label ? `${c.label} (${c.color})` : c.color;
+              subItem.setTitle(title).setIcon('circle');
               if ((subItem as any).iconEl) {
-                ((subItem as any).iconEl as HTMLElement).style.color = c;
+                ((subItem as any).iconEl as HTMLElement).style.color = c.color;
               }
               subItem.onClick(() => {
-                target.style.backgroundColor = c;
-                this.controller!.setNodeColor(id, c).then(() => this.render());
+                target.style.backgroundColor = c.color;
+                this.controller!
+                  .setNodeColor(id, c.color)
+                  .then(() => this.render());
               });
             });
           });


### PR DESCRIPTION
## Summary
- fix color menu to work with ColorOption objects
- document metadata labels for colors in settings

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b8cc82b488331bb53526c96af867e