### PR TITLE
Fix clearing selection after drag select

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -43,6 +43,7 @@ export class BoardView extends ItemView {
   private editTimer: number | null = null;
   private editingId: string | null = null;
   private pointerDownSelected = false;
+  private didDragSelect = false;
   private resizingId: string | null = null;
   private resizeDir = '';
   private resizeStartWidth = 0;
@@ -370,6 +371,7 @@ export class BoardView extends ItemView {
         this.selectionRect = this.boardEl.createDiv('vtasks-selection');
         this.selectionRect.style.left = this.selStartX + 'px';
         this.selectionRect.style.top = this.selStartY + 'px';
+        this.didDragSelect = true;
       }
     };
 
@@ -512,6 +514,9 @@ export class BoardView extends ItemView {
         });
         this.selectionRect.remove();
         this.selectionRect = null;
+        setTimeout(() => {
+          this.didDragSelect = false;
+        });
       }
     };
 
@@ -561,7 +566,10 @@ export class BoardView extends ItemView {
         }
       } else {
         this.finishEditing(true);
-        this.clearSelection();
+        if (!this.didDragSelect) {
+          this.clearSelection();
+        }
+        this.didDragSelect = false;
       }
       this.pointerDownSelected = false;
     });


### PR DESCRIPTION
## Summary
- add `didDragSelect` flag to track active rectangle selection
- keep the flag set while rectangle is active and clear it after click
- ignore `clearSelection()` in click handler when a drag selection just occurred

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b900a2a8c8331ac05fb35752745e8