### PR TITLE
Fix drag rectangle clearing selection

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -27,6 +27,7 @@ export class BoardView extends ItemView {
   private selectionRect: HTMLElement | null = null;
   private selStartX = 0;
   private selStartY = 0;
+  private didDragSelect = false;
   private isBoardDragging = false;
   private boardStartX = 0;
   private boardStartY = 0;
@@ -370,6 +371,7 @@ export class BoardView extends ItemView {
         this.selectionRect = this.boardEl.createDiv('vtasks-selection');
         this.selectionRect.style.left = this.selStartX + 'px';
         this.selectionRect.style.top = this.selStartY + 'px';
+        this.didDragSelect = true;
       }
     };
 
@@ -512,6 +514,7 @@ export class BoardView extends ItemView {
         });
         this.selectionRect.remove();
         this.selectionRect = null;
+        setTimeout(() => (this.didDragSelect = false), 0);
       }
     };
 
@@ -561,7 +564,9 @@ export class BoardView extends ItemView {
         }
       } else {
         this.finishEditing(true);
-        this.clearSelection();
+        if (!this.didDragSelect) {
+          this.clearSelection();
+        }
       }
       this.pointerDownSelected = false;
     });


### PR DESCRIPTION
## Summary
- track when rectangle selection is active with `didDragSelect`
- after selecting via rectangle, reset the flag
- avoid clearing newly selected nodes on the click following a drag

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b908c3d2c8331a04f23ca2958f9ae