### PR TITLE
Add align and rearrange options to node context menu

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -584,6 +584,39 @@ export class BoardView extends ItemView {
       const selected = Array.from(this.selectedIds);
       if (selected.length > 1) {
         menu.addItem((item) =>
+          item
+            .setTitle('Rearrange selected')
+            .onClick(() =>
+              this.controller
+                .rearrangeNodes(selected)
+                .then(() => this.render())
+            )
+        );
+        menu.addItem((item) => {
+          item.setTitle('Align');
+          item.setSubmenu((sub) => {
+            const opts: [string, Parameters<typeof this.controller.alignNodes>[1]][] = [
+              ['Left', 'left'],
+              ['Right', 'right'],
+              ['Top', 'top'],
+              ['Bottom', 'bottom'],
+              ['Horizontal center', 'hcenter'],
+              ['Vertical center', 'vcenter'],
+            ];
+            opts.forEach(([label, type]) => {
+              sub.addItem((subItem) =>
+                subItem
+                  .setTitle(label)
+                  .onClick(() =>
+                    this.controller
+                      .alignNodes(selected, type)
+                      .then(() => this.render())
+                  )
+              );
+            });
+          });
+        });
+        menu.addItem((item) =>
           item.setTitle('Group selected').onClick(async () => {
             const name = await new Promise<string>((resolve) => {
               const n = prompt('Group name', 'Group') || 'Group';


### PR DESCRIPTION
## Summary
- add new menu items for multi-selection actions in `view.ts`
- implement `rearrangeNodes` and `alignNodes` in controller

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b90aeb140833189664e96f03feeaf