### PR TITLE
Ignore right click drag actions

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -301,6 +301,7 @@ export class BoardView extends ItemView {
 
   private registerEvents() {
     this.boardEl.onpointerdown = (e) => {
+      if ((e as PointerEvent).button === 2) return;
       this.pointerDownSelected = false;
       if (this.editingId) this.finishEditing(true);
       const resizeEl = (e.target as HTMLElement).closest('.vtasks-resize') as HTMLElement | null;


### PR DESCRIPTION
## Summary
- prevent pointer events from starting drag/selection on right click
- build plugin

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c6b74ab1083319431af73386cadda