### PR TITLE
Fix command manager access

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -89,10 +89,9 @@ export default class Controller {
     const view = this.app.workspace.getActiveViewOfType(MarkdownView);
     if (!view) return;
     view.editor.setCursor({ line: task.line, ch: 0 });
-    if (this.app.commands.commands['obsidian-tasks-plugin:edit-task']) {
-      await this.app.commands.executeCommandById(
-        'obsidian-tasks-plugin:edit-task'
-      );
+    const cmdMgr = (this.app as any).commands;
+    if (cmdMgr?.commands['obsidian-tasks-plugin:edit-task']) {
+      await cmdMgr.executeCommandById('obsidian-tasks-plugin:edit-task');
     }
   }
 

--- a/src/obsidian-extras.d.ts
+++ b/src/obsidian-extras.d.ts
@@ -1,0 +1,10 @@
+import 'obsidian';
+
+declare module 'obsidian' {
+  interface App {
+    /**
+     * Access to the internal command manager.
+     */
+    commands: any;
+  }
+}


### PR DESCRIPTION
## Summary
- access Obsidian's command manager safely
- extend Obsidian types for `App.commands`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c79096cd883319a19092c576f93c7