### PR TITLE
Add submenu typings and cleanup

### DIFF
--- a/src/obsidian-extras.d.ts
+++ b/src/obsidian-extras.d.ts
@@ -7,4 +7,8 @@ declare module 'obsidian' {
      */
     commands: any;
   }
+
+  interface MenuItem {
+    setSubmenu(cb: (menu: Menu) => any): this;
+  }
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf, Menu, FuzzySuggestModal } from 'obsidian';
+import { ItemView, WorkspaceLeaf, Menu, FuzzySuggestModal, MenuItem } from 'obsidian';
 import Controller from './controller';
 import { BoardData } from './boardStore';
 import { ParsedTask } from './parser';
@@ -615,7 +615,7 @@ export class BoardView extends ItemView {
         );
         menu.addItem((item) => {
           item.setTitle('Align');
-          item.setSubmenu((sub) => {
+          item.setSubmenu((sub: Menu) => {
             const opts: [string, Parameters<typeof this.controller.alignNodes>[1]][] = [
               ['Left', 'left'],
               ['Right', 'right'],
@@ -625,7 +625,7 @@ export class BoardView extends ItemView {
               ['Vertical center', 'vcenter'],
             ];
             opts.forEach(([label, type]) => {
-              sub.addItem((subItem) =>
+              sub.addItem((subItem: MenuItem) =>
                 subItem
                   .setTitle(label)
                   .onClick(() =>
@@ -656,9 +656,8 @@ export class BoardView extends ItemView {
 
       menu.addItem((item) => {
         item.setTitle('Color').setIcon('palette');
-        console.log('Available colors:', colors);
-        item.setSubmenu((sub) => {
-          sub.addItem((subItem) =>
+        item.setSubmenu((sub: Menu) => {
+          sub.addItem((subItem: MenuItem) =>
             subItem
               .setTitle('Default')
               .onClick(() => {
@@ -668,7 +667,7 @@ export class BoardView extends ItemView {
           );
 
           colors.forEach((c) => {
-            sub.addItem((subItem) =>
+            sub.addItem((subItem: MenuItem) =>
               subItem
                 .setTitle(c.color)
                 .setIcon('circle')


### PR DESCRIPTION
## Summary
- extend Obsidian types to include `MenuItem.setSubmenu`
- remove debug log in `view.ts`
- type submenu callbacks with `Menu` and `MenuItem`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c7b769b808331804e93b5f48c6dd6