### PR TITLE
Fix selection logic when dragging nodes

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -347,7 +347,16 @@ export class BoardView extends ItemView {
           // ctrl-click handled in click event
           return;
         }
-        this.selectNode(node, id, (e as PointerEvent).shiftKey || (e as PointerEvent).metaKey);
+        const alreadySelected = this.selectedIds.has(id);
+        const modifier = (e as PointerEvent).shiftKey || (e as PointerEvent).metaKey;
+        if (alreadySelected) {
+          if (modifier) {
+            this.selectNode(node, id, true);
+          }
+          // if already selected and no modifier, keep selection as is
+        } else {
+          this.selectNode(node, id, modifier);
+        }
         this.pointerDownSelected = true;
         this.draggingId = id;
         const coords = this.getBoardCoords(e as PointerEvent);


### PR DESCRIPTION
## Summary
- keep existing selection when dragging a node that's already selected
- allow toggling when Shift/Cmd is held

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ca08fa2248331b3415cde5c54e7af