### PR TITLE
feat: add lane support

### DIFF
--- a/src/boardStore.ts
+++ b/src/boardStore.ts
@@ -1,5 +1,15 @@
 import { App, normalizePath, TFile } from 'obsidian';
 
+export interface LaneData {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  orient: 'vertical' | 'horizontal';
+}
+
 export interface NodeData {
   x: number;
   y: number;
@@ -10,12 +20,14 @@ export interface NodeData {
   name?: string;
   members?: string[];
   group?: string;
+  lane?: string;
 }
 
 export interface BoardData {
   version: number;
   nodes: Record<string, NodeData>;
   edges: { from: string; to: string; type: string }[];
+  lanes: Record<string, LaneData>;
 }
 
 const CURRENT_VERSION = 1;
@@ -23,9 +35,11 @@ const CURRENT_VERSION = 1;
 export async function loadBoard(app: App, file: TFile): Promise<BoardData> {
   try {
     const text = await app.vault.read(file);
-    return JSON.parse(text);
+    const data = JSON.parse(text) as BoardData;
+    if (!data.lanes) data.lanes = {};
+    return data;
   } catch (e) {
-    return { version: CURRENT_VERSION, nodes: {}, edges: [] };
+    return { version: CURRENT_VERSION, nodes: {}, edges: [], lanes: {} };
   }
 }
 
@@ -53,7 +67,7 @@ export async function getBoardFile(app: App, path: string): Promise<TFile> {
     try {
       await app.vault.create(
         normalized,
-        JSON.stringify({ version: CURRENT_VERSION, nodes: {}, edges: [] }, null, 2)
+        JSON.stringify({ version: CURRENT_VERSION, nodes: {}, edges: [], lanes: {} }, null, 2)
       );
     } catch (err: any) {
       if (err?.message?.includes('already exists')) {

--- a/styles.css
+++ b/styles.css
@@ -48,6 +48,43 @@
   min-width: 120px;
 }
 
+.vtasks-lane {
+  position: absolute;
+  background: var(--background-modifier-border);
+  border: 1px solid var(--background-modifier-border);
+}
+
+.vtasks-lane-header {
+  background: var(--background-secondary);
+  padding: 2px 4px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.vtasks-lane-vertical .vtasks-lane-resize {
+  position: absolute;
+  top: 0;
+  right: -2px;
+  width: 4px;
+  height: 100%;
+  cursor: ew-resize;
+}
+
+.vtasks-lane-horizontal .vtasks-lane-resize {
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 4px;
+  cursor: ns-resize;
+}
+
+.vtasks-mini-lane {
+  fill: rgba(200, 200, 200, 0.3);
+  stroke: var(--background-modifier-border);
+  stroke-width: 1;
+}
+
 .vtasks-text {
   pointer-events: none;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- introduce lanes data model and controller operations
- render lanes with interactive controls and minimap support
- include basic lane styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890986b2bb88331977f8c8e1dc9505d