### PR TITLE
Assign lanes before moving nodes

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -13,14 +13,14 @@ export default class Controller {
     public settings: PluginSettings
   ) {}
 
-  async moveNode(id: string, x: number, y: number) {
+  async moveNode(id: string, x: number, y: number, bypassLaneClamp = false) {
     const node = this.board.nodes[id];
     if (!node) return;
     let nx = x;
     let ny = y;
     const w = node.width ?? 120;
     const h = node.height ?? (node.type === 'group' ? 80 : 40);
-    if (node.lane) {
+    if (node.lane && !bypassLaneClamp) {
       const lane = this.board.lanes[node.lane];
       if (lane) {
         nx = Math.max(lane.x, Math.min(nx, lane.x + lane.width - w));

--- a/src/view.ts
+++ b/src/view.ts
@@ -706,6 +706,8 @@ export class BoardView extends ItemView {
         const id = this.resizingId;
         this.resizingId = null;
         const pos = this.board!.nodes[id];
+        const laneId = this.getLaneForNode(id);
+        this.controller!.assignNodeToLane(id, laneId ?? null);
         this.controller!.moveNode(id, pos.x, pos.y);
         this.controller!.resizeNode(
           id,
@@ -714,8 +716,6 @@ export class BoardView extends ItemView {
           this.resizeStartWidth,
           this.resizeStartHeight
         );
-        const laneId = this.getLaneForNode(id);
-        this.controller!.assignNodeToLane(id, laneId ?? null);
         this.memberResizeStart.clear();
         this.drawMinimap();
       } else if (this.draggingId) {
@@ -724,9 +724,9 @@ export class BoardView extends ItemView {
         this.alignHLine.style.display = 'none';
         this.selectedIds.forEach((id) => {
           const pos = this.board!.nodes[id];
-          this.controller!.moveNode(id, pos.x, pos.y);
           const laneId = this.getLaneForNode(id);
           this.controller!.assignNodeToLane(id, laneId ?? null);
+          this.controller!.moveNode(id, pos.x, pos.y);
         });
         this.drawMinimap();
       } else if (this.isBoardDragging) {


### PR DESCRIPTION
## Summary
- Determine a node's lane before moving it and update the lane assignment to prevent clamping against the old lane.
- Allow lane clamping to be bypassed via an optional flag in `moveNode`.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890a2e141008331ac65f8aa1e515dbf