### PR TITLE
Allow lanes to resize from all sides

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -66,22 +66,40 @@
   cursor: pointer;
 }
 
-.vtasks-lane-vertical .vtasks-lane-resize {
+.vtasks-lane-resize {
   position: absolute;
-  top: 0;
-  right: -2px;
-  width: 4px;
-  height: 100%;
-  cursor: ew-resize;
 }
 
-.vtasks-lane-horizontal .vtasks-lane-resize {
-  position: absolute;
+.vtasks-lane-resize-n,
+.vtasks-lane-resize-s {
   left: 0;
-  bottom: -2px;
   width: 100%;
   height: 4px;
   cursor: ns-resize;
+}
+
+.vtasks-lane-resize-n {
+  top: -2px;
+}
+
+.vtasks-lane-resize-s {
+  bottom: -2px;
+}
+
+.vtasks-lane-resize-e,
+.vtasks-lane-resize-w {
+  top: 0;
+  height: 100%;
+  width: 4px;
+  cursor: ew-resize;
+}
+
+.vtasks-lane-resize-e {
+  right: -2px;
+}
+
+.vtasks-lane-resize-w {
+  left: -2px;
 }
 
 .vtasks-mini-lane {


### PR DESCRIPTION
## Summary
- Support lane resizing in any direction by tracking resize handle orientation and updating lane width and height accordingly.
- Replace single lane resize handle with four directional handles (N/E/S/W).
- Style new directional handles in CSS and remove orientation-specific restrictions.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890a4262abc8331addf440e45a347e9