### PR TITLE
Improve lane interactions and task placement

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -70,7 +70,8 @@
   font-size: 0.9em;
   color: var(--text-normal);
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
-  cursor: pointer;
+  cursor: move;
+  user-select: none;
   transition: background 0.2s ease, color 0.2s ease;
 }
 


### PR DESCRIPTION
## Summary
- Prevent double-click on lane headers from creating tasks and allow renaming
- Allow lanes to be dragged via their headers and disable text selection there
- Snap tasks to centered, bottom position when dropped into a lane

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890bb2f4e908331bde4f14f428a2dd1