### PR TITLE
Fix lane dragging blocked by edge overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -136,7 +136,8 @@
 }
 
 .vtasks-edges {
-  pointer-events: auto;
+  /* Allow lanes beneath to receive drag events while edges remain clickable */
+  pointer-events: none;
   z-index: 2;
 }
 


### PR DESCRIPTION
## Summary
- Prevent edge SVG from intercepting lane drag events by disabling pointer events on `.vtasks-edges`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890c0d9f0648331a7c09fb0af9173fe