### PR TITLE
Fix group navigation and control bar layering

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -153,8 +153,8 @@ export class BoardView extends ItemView {
 
     if (this.groupId) {
       const backBtn = controls.createEl('button', { text: 'Back' });
-      backBtn.onclick = () =>
-        this.openGroup(this.board!.nodes[this.groupId!].group || null);
+      const parentId = this.board!.nodes[this.groupId!].group ?? null;
+      backBtn.onclick = () => this.openGroup(parentId);
     }
 
     this.boardEl = this.containerEl.createDiv('vtasks-board');
@@ -1380,7 +1380,8 @@ export class BoardView extends ItemView {
 
 
   private openGroup(id: string | null) {
-    this.groupId = id;
+    // null represents the root level of the board
+    this.groupId = id ?? null;
     this.clearSelection();
     this.render();
   }

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,11 @@
   display: block;
 }
 
+.vtasks-filter-bar {
+  position: relative;
+  z-index: 20;
+}
+
 .vtasks-board {
   position: relative;
   width: 100000px;


### PR DESCRIPTION
## Summary
- ensure back button opens parent group
- treat `null` as root group when navigating
- layer filter bar above board with z-index

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890cb699cec83318d3a338e03a87e46