### PR TITLE
Allow grouping without name

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -313,7 +313,7 @@ export default class Controller {
     await saveBoard(this.app, this.boardFile, this.board);
   }
 
-  async groupNodes(ids: string[], name: string) {
+  async groupNodes(ids: string[], name = '') {
     if (!ids.length) return;
     const id = 'g-' + crypto.randomBytes(4).toString('hex');
     let minX = Infinity,
@@ -336,10 +336,10 @@ export default class Controller {
       width: maxX - minX,
       height: maxY - minY,
       type: 'group',
-      name,
       members: ids,
       collapsed: false,
     };
+    if (name) groupNode.name = name;
     this.board.nodes[id] = groupNode;
     ids.forEach((nid) => {
       if (this.board.nodes[nid]) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -331,7 +331,9 @@ export class BoardView extends ItemView {
     if (pos.type === 'group' && pos.collapsed === false) {
       nodeEl.addClass('vtasks-group-container');
       const header = nodeEl.createDiv('vtasks-group-header');
-      header.createSpan({ text: pos.name || 'Group' });
+      if (pos.name) {
+        header.createSpan({ text: pos.name });
+      }
       const icon = header.createDiv('vtasks-group-toggle');
       icon.textContent = '▾';
       icon.onpointerdown = (e) => e.stopPropagation();
@@ -352,7 +354,9 @@ export class BoardView extends ItemView {
       const metaEl = nodeEl.createDiv('vtasks-meta');
       if (pos.type === 'group') {
         nodeEl.addClass('vtasks-group');
-        textEl.textContent = pos.name || 'Group';
+        if (pos.name) {
+          textEl.textContent = pos.name;
+        }
         const count = pos.members?.length || 0;
         const preview = nodeEl.createDiv('vtasks-group-preview');
         for (let i = 0; i < Math.min(4, count); i++) {
@@ -1043,13 +1047,10 @@ export class BoardView extends ItemView {
           });
         });
         menu.addItem((item) =>
-          item.setTitle('Group selected').onClick(async () => {
-            const name = await this.promptString('Group name', 'Group');
-            if (name) {
-              this.controller!
-                .groupNodes(selected, name)
-                .then(() => this.render());
-            }
+          item.setTitle('Group selected').onClick(() => {
+            this.controller!
+              .groupNodes(selected)
+              .then(() => this.render());
           })
         );
       }


### PR DESCRIPTION
## Summary
- Allow grouping selected nodes without prompting for a name
- Make `groupNodes` name parameter optional and omit name property when empty
- Only render group labels when the group has a name

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890d3c23fc48331889eaf289af6ecac