### PR TITLE
Use custom .mtask extension for board files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Key Features
 
 * **Board view**: each task becomes a draggable node.
-* **Persistent positions and connections**, saved in `*.vtasks.json` files next to your notes.
+* **Persistent positions and connections**, saved in `*.mtask` files next to your notes.
 * **Relationships between tasks** (dependency, subtask, sequence), editable via context menu.
 * **Grouping** of multiple tasks into collapsible boxes using rectangular selection.
 * **Mini-map** for quick navigation.
@@ -66,7 +66,7 @@ Relationships are stored using inline Dataview fields that reference the target 
 
   * `^id` as block anchor (default).
   * `[id:: id]` as an inline field.
-* **Board path**: choose where to save the `.vtasks.json` file; missing folders will be created automatically.
+* **Board path**: choose where to save the `.mtask` file; missing folders will be created automatically.
 * **Colors and labels**: assign colors to tags or metadata to automatically highlight nodes.
 
 ![Settings](docs/img/settings.png) <!-- TODO: settings screenshot -->

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ export default class MindTaskPlugin extends Plugin {
       const root = leaf.view.containerEl;
       root
         .querySelectorAll<HTMLElement>(
-          '.nav-file-title[data-path$=".vtasks.json"] .nav-file-title-content'
+          '.nav-file-title[data-path$=".mtask"] .nav-file-title-content'
         )
         .forEach((el) => {
           const title = el.textContent || '';
@@ -33,7 +33,7 @@ export default class MindTaskPlugin extends Plugin {
           const base = path
             .split('/')
             .pop()!
-            .replace(/\.vtasks\.json$/, '');
+            .replace(/\.mtask$/, '');
           el.textContent = base;
           parent.classList.add('mindtask-file');
           parent.onmousedown = (evt) => {
@@ -96,12 +96,12 @@ export default class MindTaskPlugin extends Plugin {
         (title) => this.renameActiveBoard(title)
       )
     );
-    this.registerExtensions(['vtasks.json'], VIEW_TYPE_BOARD);
+    this.registerExtensions(['mtask'], VIEW_TYPE_BOARD);
     this.observeExplorer();
 
     this.registerEvent(
       this.app.workspace.on('file-open', async (file) => {
-        if (!file || !file.path.endsWith('.vtasks.json')) return;
+        if (!file || !file.path.endsWith('.mtask')) return;
         await this.openBoardFile(file.path);
       })
     );
@@ -135,7 +135,7 @@ export default class MindTaskPlugin extends Plugin {
     const base = path
       .split('/')
       .pop()!
-      .replace(/\.vtasks\.json$/, '');
+      .replace(/\.mtask$/, '');
     this.activeBoard = { name: base, path };
     await this.loadBoardData(path);
     const view = this.app.workspace.getActiveViewOfType(BoardView);
@@ -318,8 +318,8 @@ export default class MindTaskPlugin extends Plugin {
                   .replace(/^-|-$/g, '');
                 const folder = this.plugin.settings.boardFolder.trim();
                 const path = folder
-                  ? `${folder.replace(/\/$/, '')}/${slug}.vtasks.json`
-                  : `${slug}.vtasks.json`;
+                  ? `${folder.replace(/\/$/, '')}/${slug}.mtask`
+                  : `${slug}.mtask`;
                 const info: BoardInfo = { name, path };
                 this.plugin.boards.push(info);
                 await getBoardFile(this.plugin.app, path);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -83,7 +83,7 @@ export class SettingsTab extends PluginSettingTab {
         )
         .addText((text) =>
           text
-            .setPlaceholder('tasks.vtasks.json')
+            .setPlaceholder('tasks.mtask')
             .setValue(b.path)
             .onChange(async (v) => {
               b.path = v.trim();
@@ -108,7 +108,7 @@ export class SettingsTab extends PluginSettingTab {
           .setButtonText('Add board')
           .setCta()
           .onClick(async () => {
-            this.plugin.boards.push({ name: 'New Board', path: 'tasks.vtasks.json' });
+            this.plugin.boards.push({ name: 'New Board', path: 'tasks.mtask' });
             await this.plugin.savePluginData();
             this.display();
           })


### PR DESCRIPTION
## Summary
- migrate board file format from `.vtasks.json` to custom `.mtask` extension so the plugin can intercept file openings
- register new extension and update settings and docs accordingly

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6891d657ecec833193f0bf7d3e24a947