### PR TITLE
fix: restrict node rendering to parent group

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -167,6 +167,17 @@ export class BoardView extends ItemView {
     for (const id in this.board.nodes) {
       const n = this.board.nodes[id];
       if (this.groupId && id === this.groupId) continue;
+      const parentId = n.group;
+      if (parentId) {
+        const g = this.board.nodes[parentId];
+        if (
+          g &&
+          parentId !== this.groupId &&
+          (g.collapsed === false || g.collapsed === true)
+        ) {
+          continue;
+        }
+      }
       const el = this.createNodeElement(id);
       nodeElements[id] = el;
       if (this.groupId && (n.group || null) !== this.groupId) {


### PR DESCRIPTION
## Summary
- avoid rendering group members outside their parent container when group collapsed or expanded

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68920bb04b448331a8dca61e84eceb80