### PR TITLE
Ensure group containers resize after member adjustments

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -858,6 +858,11 @@ export class BoardView extends ItemView {
           this.resizeStartWidth,
           this.resizeStartHeight
         );
+        if (this.groupId) {
+          this.controller!
+            .fitGroupToMembers(this.groupId)
+            .then(() => this.updateGroupFocus());
+        }
         this.memberResizeStart.clear();
         this.drawEdges();
         this.drawMinimap();


### PR DESCRIPTION
## Summary
- Resize group container to fit members after resizing a child node

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689210587f848331916e5c9b8843ec0f