### PR TITLE
Allow expanding collapsed groups in MindTask board

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -170,13 +170,8 @@ export class BoardView extends ItemView {
       const parentId = n.group;
       if (parentId) {
         const g = this.board.nodes[parentId];
-        if (
-          g &&
-          parentId !== this.groupId &&
-          (g.collapsed === false || g.collapsed === true)
-        ) {
-          continue;
-        }
+        if (g && g.collapsed === true) continue;
+        if (parentId !== this.groupId) continue;
       }
       const el = this.createNodeElement(id);
       nodeElements[id] = el;
@@ -402,6 +397,14 @@ export class BoardView extends ItemView {
       const metaEl = nodeEl.createDiv('vtasks-meta');
       if (pos.type === 'group') {
         nodeEl.addClass('vtasks-group');
+        const icon = nodeEl.createDiv('vtasks-group-toggle');
+        icon.textContent = '▸';
+        icon.onpointerdown = (e) => e.stopPropagation();
+        icon.onclick = (e) => {
+          e.stopPropagation();
+          this.controller?.toggleGroupCollapse(id).then(() => this.render());
+        };
+        nodeEl.insertBefore(icon, nodeEl.firstChild);
         if (pos.name) {
           textEl.textContent = pos.name;
         }


### PR DESCRIPTION
## Summary
- Hide nodes whose parent group is collapsed during render
- Add collapse/expand toggle to collapsed group nodes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892117481188331badd6f7d6c05be77