### PR TITLE
feat: style collapsed groups

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -397,6 +397,7 @@ export class BoardView extends ItemView {
       const metaEl = nodeEl.createDiv('vtasks-meta');
       if (pos.type === 'group') {
         nodeEl.addClass('vtasks-group');
+        if (pos.collapsed) nodeEl.addClass('vtasks-group-collapsed');
         const icon = nodeEl.createDiv('vtasks-group-toggle');
         icon.textContent = '▸';
         icon.onpointerdown = (e) => e.stopPropagation();

--- a/styles.css
+++ b/styles.css
@@ -372,6 +372,16 @@
   background: var(--background-secondary);
 }
 
+.vtasks-group-collapsed {
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+}
+
+.vtasks-group-collapsed .vtasks-group-toggle {
+  color: var(--text-muted);
+  margin-right: 4px;
+}
+
 .vtasks-group-container {
   position: absolute;
   background: transparent;


### PR DESCRIPTION
## Summary
- add `.vtasks-group-collapsed` class for consistent collapsed group styling
- apply collapsed group style in `createNodeElement`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892152c7f6c833198f6756ad76464ed