### PR TITLE
Ensure group bodies size correctly and keep children visible

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -381,11 +381,13 @@ export class BoardView extends ItemView {
         this.controller?.toggleGroupCollapse(id).then(() => this.render());
       };
       const body = nodeEl.createDiv('vtasks-group-body');
+      const headerHeight = header.offsetHeight;
+      const style = window.getComputedStyle(body);
+      const padX = parseFloat(style.paddingLeft) || 0;
+      const padY = parseFloat(style.paddingTop) || 0;
+      body.style.width = (pos.width ?? 0) - padX * 2 + 'px';
+      body.style.height = (pos.height ?? 0) - headerHeight - padY * 2 + 'px';
       if (pos.members) {
-        const headerHeight = header.offsetHeight;
-        const style = window.getComputedStyle(body);
-        const padX = parseFloat(style.paddingLeft) || 0;
-        const padY = parseFloat(style.paddingTop) || 0;
         pos.members.forEach((mid) => {
           if (this.board!.nodes[mid]) {
             this.createNodeElement(mid, body, pos.x + padX, pos.y + headerHeight + padY);

--- a/styles.css
+++ b/styles.css
@@ -402,6 +402,8 @@
 .vtasks-group-body {
   position: relative;
   padding: 4px;
+  overflow: visible;
+  box-sizing: border-box;
 }
 
 .vtasks-group-toggle {


### PR DESCRIPTION
## Summary
- Set group body dimensions based on node size and header height
- Allow group body overflow so children stay visible during drag

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68921dbdc6708331a235522babaa3c00