### PR TITLE
feat: skip grid snap for grouped node move and resize

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -714,21 +714,36 @@ export class BoardView extends ItemView {
         let y = this.resizeStartNodeY;
         let width = this.resizeStartWidth;
         let height = this.resizeStartHeight;
+        const isGrouped = !!this.board!.nodes[id].group;
 
         if (this.resizeDir.includes('w')) {
-          x = Math.round((this.resizeStartNodeX + dx) / this.gridSize) * this.gridSize;
-          width = right - x;
+          if (isGrouped) {
+            x = this.resizeStartNodeX + dx;
+            width = right - x;
+          } else {
+            x = Math.round((this.resizeStartNodeX + dx) / this.gridSize) * this.gridSize;
+            width = right - x;
+          }
         } else if (this.resizeDir.includes('e')) {
           width = this.resizeStartWidth + dx;
-          width = Math.round(width / this.gridSize) * this.gridSize;
+          if (!isGrouped) {
+            width = Math.round(width / this.gridSize) * this.gridSize;
+          }
         }
 
         if (this.resizeDir.includes('n')) {
-          y = Math.round((this.resizeStartNodeY + dy) / this.gridSize) * this.gridSize;
-          height = bottom - y;
+          if (isGrouped) {
+            y = this.resizeStartNodeY + dy;
+            height = bottom - y;
+          } else {
+            y = Math.round((this.resizeStartNodeY + dy) / this.gridSize) * this.gridSize;
+            height = bottom - y;
+          }
         } else if (this.resizeDir.includes('s')) {
           height = this.resizeStartHeight + dy;
-          height = Math.round(height / this.gridSize) * this.gridSize;
+          if (!isGrouped) {
+            height = Math.round(height / this.gridSize) * this.gridSize;
+          }
         }
 
         width = Math.max(120, width);
@@ -781,18 +796,23 @@ export class BoardView extends ItemView {
         this.getDragIds().forEach((id) => {
           const start = this.dragStartPositions.get(id);
           if (!start) return;
-          let x = Math.round((start.x + curX - this.dragStartX) / this.gridSize) * this.gridSize;
-          let y = Math.round((start.y + curY - this.dragStartY) / this.gridSize) * this.gridSize;
+          const node = this.board!.nodes[id];
+          let x = start.x + curX - this.dragStartX;
+          let y = start.y + curY - this.dragStartY;
+          if (!node.group) {
+            x = Math.round(x / this.gridSize) * this.gridSize;
+            y = Math.round(y / this.gridSize) * this.gridSize;
+          }
 
           const nodeEl = this.boardEl.querySelector(
             `.vtasks-node[data-id="${id}"]`
           ) as HTMLElement;
-          const parentId = this.board!.nodes[id].group;
+          const parentId = node.group;
           const parentX = parentId ? this.board!.nodes[parentId].x : 0;
           const parentY = parentId ? this.board!.nodes[parentId].y : 0;
           nodeEl.style.left = x - parentX + 'px';
           nodeEl.style.top = y - parentY + 'px';
-          this.board!.nodes[id] = { ...this.board!.nodes[id], x, y };
+          this.board!.nodes[id] = { ...node, x, y };
           if (id === this.draggingId) {
             const w = this.board!.nodes[id].width ?? 120;
             const h =


### PR DESCRIPTION
## Summary
- avoid snapping grouped nodes to grid during resize
- compute drag coordinates directly for grouped nodes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68921e7c20a483319d091edea9e80c1e