### PR TITLE
fix: refresh view after opening board file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -138,12 +138,17 @@ export default class MindTaskPlugin extends Plugin {
       .replace(/\.mtask$/, '');
     this.activeBoard = { name: base, path };
     await this.loadBoardData(path);
-    const view = this.app.workspace.getActiveViewOfType(BoardView);
+    let view = this.app.workspace.getActiveViewOfType(BoardView);
     if (view && this.board && this.controller) {
       view.updateData(this.board, this.tasks, this.controller);
     } else {
       const leaf = this.app.workspace.activeLeaf ?? this.app.workspace.getLeaf(true);
       await leaf.setViewState({ type: VIEW_TYPE_BOARD, active: true });
+      // After creating the leaf, ensure the view is updated with board data
+      view = this.app.workspace.getActiveViewOfType(BoardView);
+      if (view && this.board && this.controller) {
+        view.updateData(this.board, this.tasks, this.controller);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure `openBoardFile` refreshes the board view even when no board was previously opened

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689246337b9883318310558b47520e9c