### PR TITLE
feat: support dragging board files onto board view

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -179,6 +179,27 @@ export default class Controller {
     return id;
   }
 
+  async addBoardCard(
+    info: { path: string; name: string; lastModified: number; taskCount: number },
+    x: number,
+    y: number
+  ) {
+    const id = 'b-' + crypto.randomBytes(4).toString('hex');
+    this.board.nodes[id] = {
+      x,
+      y,
+      width: 160,
+      height: 80,
+      type: 'board',
+      boardPath: info.path,
+      name: info.name,
+      lastModified: info.lastModified,
+      taskCount: info.taskCount,
+    } as NodeData;
+    await saveBoard(this.app, this.boardFile, this.board);
+    return id;
+  }
+
   async addExistingTask(id: string, x: number, y: number) {
     if (!this.tasks.has(id)) return;
     this.board.nodes[id] = { x, y } as NodeData;

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,8 @@ export default class MindTaskPlugin extends Plugin {
         this.controller,
         this.board,
         this.tasks,
-        (title) => this.renameActiveBoard(title)
+        (title) => this.renameActiveBoard(title),
+        this
       )
     );
     this.registerExtensions(['mtask'], VIEW_TYPE_BOARD);
@@ -131,7 +132,7 @@ export default class MindTaskPlugin extends Plugin {
     await leaf.setViewState({ type: VIEW_TYPE_BOARD, active: true });
   }
 
-  private async openBoardFile(path: string) {
+  async openBoardFile(path: string) {
     const base = path
       .split('/')
       .pop()!

--- a/styles.css
+++ b/styles.css
@@ -456,3 +456,20 @@
 .menu-item[data-section="danger"] {
   color: var(--text-error);
 }
+
+.vtasks-board.drag-over {
+  background: #e0f7fa;
+}
+
+.vtasks-board-card {
+  border: 2px solid #888;
+  border-radius: 8px;
+  padding: 12px;
+  background: #f5f5f5;
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}
+
+.vtasks-board-card:hover {
+  box-shadow: 0 2px 8px #aaa;
+}


### PR DESCRIPTION
## Summary
- allow dropping `.mtask` files onto a board to create linkable board cards
- expose `openBoardFile` and wire `BoardView` with plugin instance
- add styling for board cards and drag-over state

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68924754a0a48331b7d845ddab214c54