### PR TITLE
refactor: remove board list and simplify plugin data

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,11 +1,6 @@
 import { App, PluginSettingTab, Setting } from 'obsidian';
 import MindTaskPlugin from './main';
 
-export interface BoardInfo {
-  name: string;
-  path: string;
-}
-
 export interface ColorOption {
   color: string;
   /**
@@ -37,7 +32,6 @@ export interface PluginSettings {
 
 export interface PluginData {
   settings: PluginSettings;
-  boards: BoardInfo[];
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
@@ -66,54 +60,6 @@ export class SettingsTab extends PluginSettingTab {
   display(): void {
     const { containerEl } = this;
     containerEl.empty();
-    containerEl.createEl('h2', { text: 'Boards' });
-    const boardsEl = containerEl.createDiv();
-    this.plugin.boards.forEach((b, i) => {
-      const boardSetting = new Setting(boardsEl).setName(b.name);
-      boardSetting
-        .addText((text) =>
-          text
-            .setPlaceholder('Board name')
-            .setValue(b.name)
-            .onChange(async (v) => {
-              b.name = v;
-              boardSetting.setName(v);
-              await this.plugin.savePluginData();
-            })
-        )
-        .addText((text) =>
-          text
-            .setPlaceholder('tasks.mtask')
-            .setValue(b.path)
-            .onChange(async (v) => {
-              b.path = v.trim();
-              await this.plugin.savePluginData();
-            })
-        )
-        .addExtraButton((btn) =>
-          btn
-            .setIcon('trash')
-            .setTooltip('Delete')
-            .onClick(async () => {
-              this.plugin.boards.splice(i, 1);
-              await this.plugin.savePluginData();
-              this.display();
-            })
-        );
-    });
-
-    new Setting(containerEl)
-      .addButton((btn) =>
-        btn
-          .setButtonText('Add board')
-          .setCta()
-          .onClick(async () => {
-            this.plugin.boards.push({ name: 'New Board', path: 'tasks.mtask' });
-            await this.plugin.savePluginData();
-            this.display();
-          })
-      );
-
     new Setting(containerEl)
       .setName('Board folder')
       .setDesc('Folder where new board files are stored')

--- a/src/view.ts
+++ b/src/view.ts
@@ -109,7 +109,7 @@ export class BoardView extends ItemView {
 
     // Get the file associated with the view
     const state = this.leaf.getViewState();
-    const filePath = (state as any).state?.file || state.file;
+    const filePath = (state as any).state?.file || (state as any).file;
     if (!filePath) return;
 
     // Load the file and board data
@@ -1793,7 +1793,6 @@ export class BoardView extends ItemView {
       if (save && this.board && this.boardFile) {
         this.board.title = newTitle;
         await saveBoard(this.app, this.boardFile, this.board);
-        await this.plugin.updateBoardInfo(this.boardFile.path, newTitle);
       }
       el.textContent = newTitle;
       input.replaceWith(el);


### PR DESCRIPTION
## Summary
- enumerate `.mtask` files from the vault instead of a saved board list
- remove board-management settings and persist only general options

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689470e52db483318a8a25f6161ac99b