### PR TITLE
feat: rely on extension registration for mtask boards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -446,12 +446,6 @@
   pointer-events: none;
 }
 
-.nav-file-title.mindtask-file .nav-file-title-content::after {
-  content: " (MindTask)";
-  opacity: 0.7;
-  font-size: 0.9em;
-}
-
 /* Style delete items in context menus */
 .menu-item[data-section="danger"] {
   color: var(--text-error);


### PR DESCRIPTION
## Summary
- remove file explorer title overrides and observers
- register `.mtask` extension directly to open BoardView
- drop unused mindtask-file styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689477c801b08331b55533dea570f783