### PR TITLE
Fix multi-board selection and highlight flashing issue

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -171,6 +171,7 @@ export class BoardView extends ItemView {
 
     if (!this.vaultEventsRegistered) {
       const onVaultChange = (file: TAbstractFile) => {
+        if (!this.hasFocus) return;
         if (!this.boardFile) return;
         if (file.path === this.boardFile.path) return;
         void this.refreshFromVault();
@@ -556,7 +557,11 @@ export class BoardView extends ItemView {
       if (pos.type === 'group') {
         this.openGroup(id);
       } else {
-        this.controller?.editTask(id);
+        this.controller?.editTask(id).then((changed) => {
+          if (changed) {
+            this.refreshFromVault();
+          }
+        });
       }
     });
 


### PR DESCRIPTION
This commit fixes a bug where having multiple boards open simultaneously would cause task highlighting to flash and selection to fail. This was due to a feedback loop where an action on one board would trigger updates on all other open boards.

The fix includes:
- Removing a global `refreshView()` method that indiscriminately re-rendered all boards.
- Making the `editTask` method in the controller report changes back to the specific view that initiated the edit.
- Adding a focus check to the vault change listener, so that only the currently active board responds to file changes. This prevents interactions on one board from being interrupted by updates from another.