### PR TITLE
Fix(view): Replace deprecated 'updateHeader' with 'layout-change' tri…

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -161,7 +161,7 @@ export class BoardView extends ItemView {
     this.tasks = tasks;
     this.controller = controller;
     this.boardFile = boardFile;
-    this.leaf.updateHeader();
+    this.app.workspace.trigger('layout-change');
 
     if (!this.vaultEventsRegistered) {
       const onVaultChange = (file: TAbstractFile) => {
@@ -1832,7 +1832,7 @@ export class BoardView extends ItemView {
       if (save && this.board && this.boardFile) {
         this.board.title = newTitle;
         await saveBoard(this.app, this.boardFile, this.board);
-        this.leaf.updateHeader();
+        this.app.workspace.trigger('layout-change');
       }
       el.textContent = newTitle;
       input.replaceWith(el);


### PR DESCRIPTION
…gger

The `this.leaf.updateHeader()` method has been removed in recent versions of the Obsidian API, causing a TypeScript compilation error.

This change replaces the deprecated method call with `this.app.workspace.trigger('layout-change')`. This is a more modern way to signal to Obsidian that the view's display text may have changed and that the UI needs to be refreshed. This resolves the compilation error and ensures that the view header updates correctly when the board title is changed.