### PR TITLE
Fix(view): Refresh board on file modify regardless of focus

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -165,7 +165,6 @@ export class BoardView extends ItemView {
 
     if (!this.vaultEventsRegistered) {
       const onVaultChange = (file: TAbstractFile) => {
-        if (!this.hasFocus) return;
         if (!this.boardFile) return;
         if (file.path === this.boardFile.path) return;
         void this.refreshFromVault();


### PR DESCRIPTION
This commit fixes a bug where the board view would not update if changes were made to a task's underlying .md file while the board view was not in focus. This led to data inconsistencies and errors.

The `onVaultChange` event handler in `BoardView` previously had a check `if (!this.hasFocus) return;` which prevented the view from refreshing. This check has been removed, ensuring that the board now correctly detects and reflects changes from external file modifications, regardless of tab focus.