### PR TITLE
Ignore unrelated board updates

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -165,8 +165,13 @@ export class BoardView extends ItemView {
 
     if (!this.vaultEventsRegistered) {
       const onVaultChange = (file: TAbstractFile) => {
-        if (!this.boardFile) return;
-        if (file.path === this.boardFile.path) return;
+        if (!this.boardFile || !(file instanceof TFile)) return;
+        if (
+          file.path === this.boardFile.path ||
+          file.path.endsWith('.mtask') ||
+          !file.path.endsWith('.md')
+        )
+          return;
         void this.refreshFromVault();
       };
       this.registerEvent(this.app.vault.on('create', onVaultChange));


### PR DESCRIPTION
## Summary
- prevent board refresh when the changed file is the current board or another `.mtask` file
- refresh only on markdown file changes for live updates

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895c40f6f5c833191f0c560af0b8d79