### PR TITLE
Preserve selection after board refresh

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -237,8 +237,19 @@ export class BoardView extends ItemView {
       this.tasks,
       this.plugin.settings
     );
-
+    const prevSelected = new Set(this.selectedIds);
     this.render();
+    this.selectedIds.clear();
+    prevSelected.forEach((id) => {
+      if (!this.board?.nodes[id]) return;
+      const el = this.boardEl.querySelector(
+        `.vtasks-node[data-id="${id}"]`
+      ) as HTMLElement | null;
+      if (el) {
+        el.classList.add('selected');
+        this.selectedIds.add(id);
+      }
+    });
   }
 
   private render() {


### PR DESCRIPTION
## Summary
- Keep previously selected nodes when board refreshes from vault changes
- Reapply selection and CSS classes after re-rendering while ignoring removed nodes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895cc10b9508331a9d29429e090521b