### PR TITLE
feat(board): add board-level settings

### DIFF
--- a/src/boardStore.ts
+++ b/src/boardStore.ts
@@ -26,6 +26,7 @@ export interface BoardData {
   edges: { from: string; to: string; type: string }[];
   lanes: Record<string, LaneData>;
   title?: string;
+  orientation?: 'vertical' | 'horizontal';
 }
 
 const CURRENT_VERSION = 1;
@@ -36,6 +37,7 @@ export async function loadBoard(app: App, file: TFile): Promise<BoardData> {
     const data = JSON.parse(text) as BoardData;
     if (!data.lanes) data.lanes = {};
     if (!data.title) data.title = file.basename;
+    if (!data.orientation) data.orientation = 'vertical';
     return data;
   } catch (e) {
     return {
@@ -44,6 +46,7 @@ export async function loadBoard(app: App, file: TFile): Promise<BoardData> {
       edges: [],
       lanes: {},
       title: file.basename,
+      orientation: 'vertical',
     };
   }
 }
@@ -72,7 +75,11 @@ export async function getBoardFile(app: App, path: string): Promise<TFile> {
     try {
       await app.vault.create(
         normalized,
-        JSON.stringify({ version: CURRENT_VERSION, nodes: {}, edges: [], lanes: {} }, null, 2)
+        JSON.stringify(
+          { version: CURRENT_VERSION, nodes: {}, edges: [], lanes: {}, orientation: 'vertical' },
+          null,
+          2
+        )
       );
     } catch (err: any) {
       if (err?.message?.includes('already exists')) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -116,6 +116,11 @@ export default class Controller {
     await saveBoard(this.app, this.boardFile, this.board);
   }
 
+  async setOrientation(orient: 'vertical' | 'horizontal') {
+    this.board.orientation = orient;
+    await saveBoard(this.app, this.boardFile, this.board);
+  }
+
   async setLaneOrientation(
     id: string,
     orient: 'vertical' | 'horizontal'
@@ -422,7 +427,7 @@ export default class Controller {
       .filter((p) => p.node);
     if (!nodes.length) return;
 
-    const orient = this.settings.orientation ?? 'vertical';
+    const orient = this.board.orientation ?? 'vertical';
     const spacingA =
       orient === 'vertical'
         ? this.settings.rearrangeSpacingX

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,8 +26,6 @@ export interface PluginSettings {
   rearrangeSpacingX: number;
   /** Vertical spacing between nodes when rearranging */
   rearrangeSpacingY: number;
-  /** Orientation of node layout */
-  orientation: 'vertical' | 'horizontal';
 }
 
 export interface PluginData {
@@ -49,7 +47,6 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   ],
   rearrangeSpacingX: 40,
   rearrangeSpacingY: 40,
-  orientation: 'vertical',
 };
 
 export class SettingsTab extends PluginSettingTab {
@@ -171,20 +168,6 @@ export class SettingsTab extends PluginSettingTab {
             await this.plugin.savePluginData();
           });
       });
-
-    new Setting(containerEl)
-      .setName('Orientation')
-      .setDesc('Direction for arranged nodes')
-      .addDropdown((dropdown) =>
-        dropdown
-          .addOption('vertical', 'Vertical')
-          .addOption('horizontal', 'Horizontal')
-          .setValue(this.plugin.settings.orientation)
-          .onChange(async (value) => {
-            this.plugin.settings.orientation = value as 'vertical' | 'horizontal';
-            await this.plugin.savePluginData();
-          })
-      );
 
     containerEl.createEl('h2', { text: 'Background colors' });
     const colorsEl = containerEl.createDiv();

--- a/src/view.ts
+++ b/src/view.ts
@@ -257,21 +257,12 @@ export class BoardView extends ItemView {
     this.containerEl.empty();
     this.containerEl.addClass('vtasks-container');
     const topBar = this.containerEl.createDiv('vtasks-top-bar');
-    const left = topBar.createDiv('vtasks-top-left');
     const titleEl = topBar.createDiv('vtasks-board-title');
     titleEl.setText(this.board.title || 'Board');
     titleEl.onclick = () => this.editTitle(titleEl);
-    const right = topBar.createDiv('vtasks-top-right');
-    const settingsBtn = right.createDiv('vtasks-top-button');
-    setIcon(settingsBtn, 'settings');
-    settingsBtn.setAttr('title', 'Board settings');
-    settingsBtn.onclick = () => {
-      (this.app as any).setting.open();
-      (this.app as any).setting.openTabById('mind-task');
-    };
 
     this.boardEl = this.containerEl.createDiv('vtasks-board');
-    const orient = this.controller?.settings.orientation ?? 'vertical';
+    const orient = this.board?.orientation ?? 'vertical';
     this.boardEl.addClass(
       orient === 'horizontal' ? 'vtasks-horizontal' : 'vtasks-vertical'
     );
@@ -333,6 +324,31 @@ export class BoardView extends ItemView {
     setIcon(fitBtn, 'maximize');
     fitBtn.setAttr('title', 'Zoom to fit');
     fitBtn.onclick = () => this.zoomToFit();
+
+    const settingsBtn = zoomSection.createEl('button');
+    setIcon(settingsBtn, 'settings');
+    settingsBtn.setAttr('title', 'Board settings');
+    settingsBtn.onclick = (e) => {
+      const menu = new Menu();
+      const current = this.board?.orientation ?? 'vertical';
+      menu.addItem((item) =>
+        item.setTitle('Vertical orientation').onClick(async () => {
+          if (current !== 'vertical') {
+            await this.controller?.setOrientation('vertical');
+            this.render();
+          }
+        })
+      );
+      menu.addItem((item) =>
+        item.setTitle('Horizontal orientation').onClick(async () => {
+          if (current !== 'horizontal') {
+            await this.controller?.setOrientation('horizontal');
+            this.render();
+          }
+        })
+      );
+      menu.showAtMouseEvent(e as MouseEvent);
+    };
 
     this.registerEvents();
 
@@ -455,7 +471,7 @@ export class BoardView extends ItemView {
     nodeEl.style.borderColor = pos.color || defaultColor;
     if (pos.color) nodeEl.style.backgroundColor = pos.color;
 
-    const orientH = this.controller?.settings.orientation ?? 'vertical';
+    const orientH = this.board?.orientation ?? 'vertical';
     nodeEl.createDiv(
       `vtasks-handle vtasks-handle-in vtasks-handle-${orientH === 'vertical' ? 'top' : 'left'}`
     );
@@ -1170,7 +1186,7 @@ export class BoardView extends ItemView {
         const menu = new Menu();
         menu.addItem((item) =>
           item.setTitle('Create lane').onClick(() => {
-            const orient = this.controller?.settings.orientation ?? 'vertical';
+            const orient = this.board?.orientation ?? 'vertical';
             this.controller!
               .createLane('Lane', pos.x, pos.y, 300, 300, orient)
               .then(() => this.render());
@@ -1461,7 +1477,7 @@ export class BoardView extends ItemView {
       const y1 = (fr.top - boardRect.top + fr.height / 2) / this.zoom;
       const x2 = (tr.left - boardRect.left + tr.width / 2) / this.zoom;
       const y2 = (tr.top - boardRect.top + tr.height / 2) / this.zoom;
-      const orientD = this.controller?.settings.orientation ?? 'vertical';
+      const orientD = this.board?.orientation ?? 'vertical';
       let d: string;
       if (orientD === 'horizontal') {
         const dx = Math.abs(x2 - x1);


### PR DESCRIPTION
## Summary
- add orientation to board data with default vertical value
- move settings gear into toolbar with orientation menu
- drop global orientation setting in favor of board-specific option

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895cefc9afc83318537cf4f302d4492