### PR TITLE
Add check toggle for task cards

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -555,7 +555,25 @@ export class BoardView extends ItemView {
     }
     const tagsEl = metaEl.createDiv('vtasks-tags');
     tags.forEach((t) => tagsEl.createSpan({ text: t, cls: 'vtasks-tag' }));
-    if (task?.checked) nodeEl.addClass('done');
+    if (pos.type !== 'group') {
+      nodeEl.addClass('vtasks-task');
+      const checked = task?.checked ?? false;
+      const checkEl = nodeEl.createDiv('vtasks-check');
+      setIcon(checkEl, checked ? 'check-circle' : 'circle');
+      checkEl.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const newVal = !this.tasks.get(id)?.checked;
+        if (newVal) {
+          nodeEl.addClass('done');
+          setIcon(checkEl, 'check-circle');
+        } else {
+          nodeEl.removeClass('done');
+          setIcon(checkEl, 'circle');
+        }
+        this.controller!.setCheck(id, newVal).then(() => this.render());
+      });
+      if (checked) nodeEl.addClass('done');
+    }
     const outHandle = nodeEl.createDiv(
       `vtasks-handle vtasks-handle-out vtasks-handle-${orientH === 'vertical' ? 'bottom' : 'right'}`
     );

--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,10 @@
   z-index: 3;
 }
 
+.vtasks-task {
+  padding-right: 24px;
+}
+
 .vtasks-lane {
   position: absolute;
   background: #e6e6e63d;
@@ -406,6 +410,20 @@
   border-radius: 4px;
   font: inherit;
   margin: 0;
+}
+
+.vtasks-check {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 16px;
+  height: 16px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.vtasks-node.done .vtasks-check {
+  color: var(--color-green);
 }
 
 .vtasks-node.done {


### PR DESCRIPTION
## Summary
- add clickable check circle in task cards to mark tasks done or undone
- style check icon with green color and preserve green outline on completion

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895d5fdba1083318e47ae2ef90bf31c