### PR TITLE
feat: add grid snap toggle

### DIFF
--- a/src/boardStore.ts
+++ b/src/boardStore.ts
@@ -27,6 +27,8 @@ export interface BoardData {
   lanes: Record<string, LaneData>;
   title?: string;
   orientation?: 'vertical' | 'horizontal';
+  /** Whether nodes snap to the background grid */
+  snapToGrid?: boolean;
 }
 
 const CURRENT_VERSION = 1;
@@ -38,6 +40,7 @@ export async function loadBoard(app: App, file: TFile): Promise<BoardData> {
     if (!data.lanes) data.lanes = {};
     if (!data.title) data.title = file.basename;
     if (!data.orientation) data.orientation = 'vertical';
+    if (data.snapToGrid === undefined) data.snapToGrid = true;
     return data;
   } catch (e) {
     return {
@@ -47,6 +50,7 @@ export async function loadBoard(app: App, file: TFile): Promise<BoardData> {
       lanes: {},
       title: file.basename,
       orientation: 'vertical',
+      snapToGrid: true,
     };
   }
 }
@@ -76,7 +80,14 @@ export async function getBoardFile(app: App, path: string): Promise<TFile> {
       await app.vault.create(
         normalized,
         JSON.stringify(
-          { version: CURRENT_VERSION, nodes: {}, edges: [], lanes: {}, orientation: 'vertical' },
+          {
+            version: CURRENT_VERSION,
+            nodes: {},
+            edges: [],
+            lanes: {},
+            orientation: 'vertical',
+            snapToGrid: true,
+          },
           null,
           2
         )

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -121,6 +121,11 @@ export default class Controller {
     await saveBoard(this.app, this.boardFile, this.board);
   }
 
+  async setSnapToGrid(enable: boolean) {
+    this.board.snapToGrid = enable;
+    await saveBoard(this.app, this.boardFile, this.board);
+  }
+
   async setLaneOrientation(
     id: string,
     orient: 'vertical' | 'horizontal'

--- a/src/view.ts
+++ b/src/view.ts
@@ -267,6 +267,9 @@ export class BoardView extends ItemView {
     this.boardEl.addClass(
       orient === 'horizontal' ? 'vtasks-horizontal' : 'vtasks-vertical'
     );
+    if (!(this.board?.snapToGrid ?? true)) {
+      this.boardEl.addClass('vtasks-no-grid');
+    }
     this.boardEl.tabIndex = 0;
     this.boardEl.style.transform = `translate(${this.boardOffsetX}px, ${this.boardOffsetY}px) scale(${this.zoom})`;
     this.alignVLine = this.boardEl.createDiv('vtasks-align-line vtasks-align-v');
@@ -331,6 +334,16 @@ export class BoardView extends ItemView {
     settingsBtn.setAttr('title', 'Board settings');
     settingsBtn.onclick = (e) => {
       const menu = new Menu();
+      const snap = this.board?.snapToGrid ?? true;
+      menu.addItem((item) =>
+        item
+          .setTitle('Snap to grid')
+          .setChecked(snap)
+          .onClick(async () => {
+            await this.controller?.setSnapToGrid(!snap);
+            this.render();
+          })
+      );
       const current = this.board?.orientation ?? 'vertical';
       menu.addItem((item) =>
         item.setTitle('Vertical orientation').onClick(async () => {
@@ -845,6 +858,7 @@ export class BoardView extends ItemView {
 
     this.boardEl.onpointermove = (e) => {
       const coords = this.getBoardCoords(e as PointerEvent);
+      const snap = this.board?.snapToGrid ?? true;
       const laneId = this.getLaneForPosition(coords.x, coords.y);
       this.boardEl.querySelectorAll('.vtasks-lane').forEach((l) => {
         const el = l as HTMLElement;
@@ -914,19 +928,21 @@ export class BoardView extends ItemView {
         let height = this.resizeStartHeight;
 
         if (this.resizeDir.includes('w')) {
-          x = Math.round((this.resizeStartNodeX + dx) / this.gridSize) * this.gridSize;
+          x = this.resizeStartNodeX + dx;
+          if (snap) x = Math.round(x / this.gridSize) * this.gridSize;
           width = right - x;
         } else if (this.resizeDir.includes('e')) {
           width = this.resizeStartWidth + dx;
-          width = Math.round(width / this.gridSize) * this.gridSize;
+          if (snap) width = Math.round(width / this.gridSize) * this.gridSize;
         }
 
         if (this.resizeDir.includes('n')) {
-          y = Math.round((this.resizeStartNodeY + dy) / this.gridSize) * this.gridSize;
+          y = this.resizeStartNodeY + dy;
+          if (snap) y = Math.round(y / this.gridSize) * this.gridSize;
           height = bottom - y;
         } else if (this.resizeDir.includes('s')) {
           height = this.resizeStartHeight + dy;
-          height = Math.round(height / this.gridSize) * this.gridSize;
+          if (snap) height = Math.round(height / this.gridSize) * this.gridSize;
         }
 
         width = Math.max(120, width);
@@ -979,8 +995,12 @@ export class BoardView extends ItemView {
         this.getDragIds().forEach((id) => {
           const start = this.dragStartPositions.get(id);
           if (!start) return;
-          let x = Math.round((start.x + curX - this.dragStartX) / this.gridSize) * this.gridSize;
-          let y = Math.round((start.y + curY - this.dragStartY) / this.gridSize) * this.gridSize;
+          let x = start.x + curX - this.dragStartX;
+          let y = start.y + curY - this.dragStartY;
+          if (snap) {
+            x = Math.round(x / this.gridSize) * this.gridSize;
+            y = Math.round(y / this.gridSize) * this.gridSize;
+          }
 
           const nodeEl = this.boardEl.querySelector(
             `.vtasks-node[data-id="${id}"]`

--- a/styles.css
+++ b/styles.css
@@ -90,6 +90,10 @@
   transform-origin: 0 0; /* oppure usa 'center center' per zoomare dal centro */
 }
 
+.vtasks-no-grid {
+  background-image: none;
+}
+
 .vtasks-align-line {
   position: absolute;
   background: var(--color-accent);


### PR DESCRIPTION
## Summary
- allow boards to toggle grid snapping
- persist snap-to-grid in board files
- hide grid background when snapping is disabled

## Testing
- `npm test`
- `npx tsc --noEmit --rootDir .` *(fails: Property 'app' does not exist on type 'BoardView', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6895f905480c8331b9905d3e8f928e8e