### PR TITLE
Improve handle visibility and drag feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rollup -c && cp manifest.json styles.css dist/",
     "dev": "rollup -c -w",
-    "test": "tsx test/boardHandles.test.ts"
+    "test": "tsx test/boardHandles.test.ts && tsx test/connectedHandles.test.ts"
   },
   "keywords": [
     "obsidian-plugin"

--- a/styles.css
+++ b/styles.css
@@ -279,11 +279,15 @@
   border-radius: 50%;
   background: var(--color-accent);
   opacity: 0;
-  transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out, transform 0.1s ease-in-out;
 }
 
 .vtasks-node:hover .vtasks-handle,
 .vtasks-board.show-handles .vtasks-handle {
+  opacity: 1;
+}
+
+.vtasks-handle-connected {
   opacity: 1;
 }
 
@@ -293,10 +297,18 @@
   transform: translate(-50%, -50%);
 }
 
+.vtasks-vertical .vtasks-handle-top.vtasks-handle-hover {
+  transform: translate(-50%, -50%) scale(1.4);
+}
+
 .vtasks-vertical .vtasks-handle-bottom {
   bottom: -5px;
   left: 50%;
   transform: translate(-50%, 50%);
+}
+
+.vtasks-vertical .vtasks-handle-bottom.vtasks-handle-hover {
+  transform: translate(-50%, 50%) scale(1.4);
 }
 
 .vtasks-horizontal .vtasks-handle-left {
@@ -305,10 +317,18 @@
   transform: translate(-50%, -50%);
 }
 
+.vtasks-horizontal .vtasks-handle-left.vtasks-handle-hover {
+  transform: translate(-50%, -50%) scale(1.4);
+}
+
 .vtasks-horizontal .vtasks-handle-right {
   right: -5px;
   top: 50%;
   transform: translate(50%, -50%);
+}
+
+.vtasks-horizontal .vtasks-handle-right.vtasks-handle-hover {
+  transform: translate(50%, -50%) scale(1.4);
 }
 
 .vtasks-resize {

--- a/test/connectedHandles.test.ts
+++ b/test/connectedHandles.test.ts
@@ -1,0 +1,100 @@
+import { JSDOM } from 'jsdom';
+import { BoardView } from '../src/view';
+
+declare global {
+  interface Window {
+    ResizeObserver: any;
+  }
+}
+
+const dom = new JSDOM('<!doctype html><div id="root"></div>');
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+
+class RO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = RO;
+
+const hProto = dom.window.HTMLElement.prototype as any;
+hProto.createDiv = function(arg: any) {
+  const el = dom.window.document.createElement('div');
+  if (typeof arg === 'string') {
+    el.className = arg;
+  } else if (arg?.cls) {
+    el.className = arg.cls;
+  }
+  if (typeof arg === 'object' && arg?.text) {
+    el.textContent = arg.text;
+  }
+  this.appendChild(el);
+  return el;
+};
+hProto.createSpan = function(arg: any) {
+  const el = dom.window.document.createElement('span');
+  if (arg?.cls) el.className = arg.cls;
+  if (arg?.text) el.textContent = arg.text;
+  this.appendChild(el);
+  return el;
+};
+hProto.setAttr = function(name: string, value: string) {
+  this.setAttribute(name, value);
+};
+hProto.addClass = function(cls: string) {
+  this.classList.add(cls);
+};
+hProto.removeClass = function(cls: string) {
+  this.classList.remove(cls);
+};
+hProto.setText = function(text: string) {
+  this.textContent = text;
+};
+
+const sProto = dom.window.SVGElement.prototype as any;
+sProto.setAttr = function(name: string, value: string) {
+  this.setAttribute(name, value);
+};
+sProto.addClass = function(cls: string) {
+  this.classList.add(cls);
+};
+sProto.removeClass = function(cls: string) {
+  this.classList.remove(cls);
+};
+
+const root = document.getElementById('root')!;
+
+const view: any = {
+  board: {
+    orientation: 'vertical',
+    nodes: {
+      b1: { x: 0, y: 0, type: 'board', name: 'B1', taskCount: 0 },
+      b2: { x: 100, y: 100, type: 'board', name: 'B2', taskCount: 0 },
+    },
+    edges: [ { from: 'b1', to: 'b2', type: 'depends' } ],
+  },
+  tasks: new Map(),
+  boardEl: root,
+  svgEl: document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+  edgeEls: new Map(),
+  controller: { settings: {} },
+  groupId: null,
+  drawMinimap: () => {},
+  updateOverflow: () => {},
+};
+
+(BoardView.prototype as any).createNodeElement.call(view, 'b1', root);
+(BoardView.prototype as any).createNodeElement.call(view, 'b2', root);
+
+(BoardView.prototype as any).drawEdges.call(view);
+
+const fromHandle = root.querySelector('.vtasks-node[data-id="b1"] .vtasks-handle-out');
+const toHandle = root.querySelector('.vtasks-node[data-id="b2"] .vtasks-handle-in');
+
+if (!fromHandle?.classList.contains('vtasks-handle-connected') ||
+    !toHandle?.classList.contains('vtasks-handle-connected')) {
+  throw new Error('Connected handles should be visible');
+}
+
+console.log('Connected handles are visible');


### PR DESCRIPTION
## Summary
- Keep connection handles visible on connected nodes
- Enlarge handles while dragging connections for easier snapping
- Test handle visibility when nodes are connected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896313542888331a359e50d9a75ce79