### PR TITLE
Add note path suggestions to task editor

### DIFF
--- a/src/noteSuggest.ts
+++ b/src/noteSuggest.ts
@@ -1,0 +1,23 @@
+import { App, TFile, AbstractInputSuggest } from 'obsidian';
+
+export class NoteSuggest extends AbstractInputSuggest<TFile> {
+  constructor(app: App, inputEl: HTMLInputElement) {
+    super(app, inputEl);
+  }
+
+  getSuggestions(query: string): TFile[] {
+    const files = this.app.vault.getMarkdownFiles();
+    return files.filter((f) =>
+      f.path.toLowerCase().includes(query.toLowerCase()),
+    );
+  }
+
+  renderSuggestion(file: TFile, el: HTMLElement): void {
+    el.setText(file.path);
+  }
+
+  selectSuggestion(file: TFile): void {
+    this.inputEl.value = file.path;
+    this.inputEl.dispatchEvent(new Event('input'));
+  }
+}

--- a/src/taskEditModal.ts
+++ b/src/taskEditModal.ts
@@ -8,6 +8,7 @@ import {
   DropdownComponent,
   normalizePath,
 } from 'obsidian';
+import { NoteSuggest } from './noteSuggest';
 import { ParsedTask } from './parser';
 import { PluginSettings } from './settings';
 
@@ -146,7 +147,10 @@ export async function openTaskEditModal(
             .addTextArea((t) => (this.description = t.setValue(task.description || '')));
         new Setting(contentEl)
           .setName('Note Path')
-          .addText((t) => (this.notePath = t.setValue(metas.get('notePath') || '')))
+          .addText((t) => {
+            this.notePath = t.setValue(metas.get('notePath') || '');
+            new NoteSuggest(app, t.inputEl);
+          })
           .addExtraButton((btn) =>
             btn
               .setIcon('file')

--- a/test/obsidian.ts
+++ b/test/obsidian.ts
@@ -84,6 +84,18 @@ export class TextComponent {
   getValue(): string { return this.inputEl.value; }
 }
 
+export class PopoverSuggest<T> {
+  constructor(public app: App) {}
+  open(): void {}
+  close(): void {}
+}
+
+export abstract class AbstractInputSuggest<T> extends PopoverSuggest<T> {
+  constructor(app: App, public inputEl: HTMLInputElement) {
+    super(app);
+  }
+}
+
 export class TAbstractFile {}
 export class TFile extends TAbstractFile {
   path = '';


### PR DESCRIPTION
## Summary
- add `NoteSuggest` component to provide note path autocompletion
- wire note path field in task editor to use note suggestions
- extend test obsidian mock with `AbstractInputSuggest`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a45a4c9878833182bd90da68540b82