### PR TITLE
Ignore label double-clicks when creating tasks

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -1308,7 +1308,9 @@ export class BoardView extends ItemView {
       this.boardEl.ondblclick = (e) => {
         if (
           (e.target as HTMLElement).closest('.vtasks-node') ||
-          (e.target as HTMLElement).closest('.vtasks-lane-header')
+          (e.target as HTMLElement).closest('.vtasks-lane-header') ||
+          (e.target as HTMLElement).closest('.vtasks-edge') ||
+          (e.target as HTMLElement).closest('.vtasks-edge-label')
         )
           return;
         const pos = this.getBoardCoords(e as MouseEvent);


### PR DESCRIPTION
## Summary
- Prevent new task creation when double-clicking edge labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4618362fc8331a8b92217f6e8fd75