### PR TITLE
Fix folder detection and note suggestion input

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -275,7 +275,7 @@ export default class Controller {
         }
         f = this.app.vault.getAbstractFileByPath(folderPath);
       }
-      folder = f instanceof TFolder ? f : this.app.vault.getRoot();
+      folder = f && 'children' in f ? (f as TFolder) : this.app.vault.getRoot();
     } else {
       folder = task.file.parent ?? this.app.vault.getRoot();
     }

--- a/src/noteSuggest.ts
+++ b/src/noteSuggest.ts
@@ -1,7 +1,7 @@
 import { App, TFile, AbstractInputSuggest } from 'obsidian';
 
 export class NoteSuggest extends AbstractInputSuggest<TFile> {
-  constructor(app: App, inputEl: HTMLInputElement) {
+  constructor(app: App, private inputEl: HTMLInputElement) {
     super(app, inputEl);
   }
 


### PR DESCRIPTION
## Summary
- use property checks instead of `TFolder` instance to determine vault folder, eliminating type import error
- store the input element on `NoteSuggest` so suggestions set the field value properly

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a466a431488331993b9971543cb78b