### PR TITLE
Refine board card interactions and styling

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -540,7 +540,7 @@ export class BoardView extends ItemView {
         this.updateOverflow(nodeEl);
       }).observe(nodeEl);
       this.updateOverflow(nodeEl);
-      nodeEl.addEventListener('click', (e) => {
+      nodeEl.addEventListener('dblclick', (e) => {
         e.stopPropagation();
         if ((pos as any).boardPath) {
           this.plugin.openBoardFile((pos as any).boardPath);

--- a/styles.css
+++ b/styles.css
@@ -552,14 +552,16 @@ input.vtasks-edge-label-input {
 }
 
 .vtasks-board-card {
-  border: 2px solid #888;
+  border: 2px dashed var(--background-modifier-border);
   border-radius: 8px;
   padding: 12px;
-  background: #f5f5f5;
+  background: var(--background-secondary);
+  color: var(--text-normal);
   cursor: pointer;
-  transition: box-shadow 0.2s;
+  transition: box-shadow 0.2s, background 0.2s;
 }
 
 .vtasks-board-card:hover {
-  box-shadow: 0 2px 8px #aaa;
+  background: var(--background-modifier-hover);
+  box-shadow: 0 2px 8px var(--background-modifier-border);
 }


### PR DESCRIPTION
## Summary
- Open board cards on double-click while single-click selects them
- Improve board card styling with dashed border and theme-aware background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4796f27ec8331ab9123a39d4ed8a2