### PR TITLE
Fix board card persistence and allow linking tasks to mtask files

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -233,7 +233,9 @@ export class BoardView extends ItemView {
 
     for (const id of Object.keys(this.board.nodes)) {
       const n = this.board.nodes[id] as any;
-      if (!this.tasks.has(id) && n.type !== 'group') delete this.board.nodes[id];
+      // Only remove nodes that correspond to tasks no longer present.
+      // Preserve board, note and other special nodes which have a type set.
+      if (!this.tasks.has(id) && !n.type) delete this.board.nodes[id];
     }
 
     this.board.edges = this.board.edges.filter(


### PR DESCRIPTION
## Summary
- prevent refresh from deleting non-task nodes like board cards
- allow creating and editing edges that involve board nodes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48c78846483319bb6d83e11de72d1