### PR TITLE
feat: enable inline task title editing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -247,9 +247,15 @@
 }
 
 .vtasks-text {
-  pointer-events: none;
+  pointer-events: auto;
   overflow: hidden;
   max-height: 100%;
+}
+
+.vtasks-inline-edit {
+  background: transparent;
+  border: none;
+  outline: none;
 }
 
 .vtasks-text.vtasks-fade {


### PR DESCRIPTION
## Summary
- allow clicking task text to rename inline with contentEditable
- style inline editor and permit text clicks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a574d7c5908331bf40ec0b04ae8e81