### PR TITLE
Fix board link loss on refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rollup -c && cp manifest.json styles.css dist/",
     "dev": "rollup -c -w",
-    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts"
+    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts"
   },
   "keywords": [
     "obsidian-plugin"

--- a/src/view.ts
+++ b/src/view.ts
@@ -239,14 +239,19 @@ export class BoardView extends ItemView {
     }
 
     this.board.edges = this.board.edges.filter(
-      (e) =>
-        (this.tasks.has(e.from) || this.board!.nodes[e.from]?.type === 'group') &&
-        (this.tasks.has(e.to) || this.board!.nodes[e.to]?.type === 'group')
+      (e) => this.board!.nodes[e.from] && this.board!.nodes[e.to]
     );
 
-    const existing = this.board.edges.filter((e) =>
-      deps.some((d) => d.from === e.from && d.to === e.to && d.type === e.type)
-    );
+    const existing = this.board.edges.filter((e) => {
+      const fromTask = this.tasks.has(e.from);
+      const toTask = this.tasks.has(e.to);
+      if (fromTask && toTask) {
+        return deps.some(
+          (d) => d.from === e.from && d.to === e.to && d.type === e.type
+        );
+      }
+      return true;
+    });
 
     for (const dep of deps) {
       if (

--- a/test/preserveBoardLinks.test.ts
+++ b/test/preserveBoardLinks.test.ts
@@ -1,0 +1,53 @@
+import { JSDOM } from 'jsdom';
+import { BoardView } from '../src/view';
+
+declare global {
+  interface Window { ResizeObserver: any; }
+}
+
+const dom = new JSDOM('<!doctype html><div id="root"></div>');
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const file: any = { path: 'task.md', basename: 'task' };
+const boardFile: any = { path: 'board.mtask', basename: 'board' };
+
+const app: any = {
+  vault: {
+    getMarkdownFiles: () => [file],
+    read: async () => '- [ ] Task ^t1\n',
+    modify: async () => {},
+    getAbstractFileByPath: () => null,
+  },
+};
+
+const view: any = {
+  app,
+  boardFile,
+  board: {
+    nodes: {
+      t1: { x: 0, y: 0 },
+      b1: { x: 100, y: 100, type: 'board', name: 'B1', taskCount: 0 },
+    },
+    edges: [{ from: 'b1', to: 't1', type: 'depends' }],
+    lanes: {},
+  },
+  tasks: new Map(),
+  plugin: { settings: { tagFilters: [], folderPaths: [], useBlockId: true } },
+  selectedIds: new Set(),
+  boardEl: dom.window.document.getElementById('root'),
+  render: () => {},
+};
+
+await (BoardView.prototype as any).refreshFromVault.call(view);
+
+if (view.board.edges.length !== 1) {
+  throw new Error('Board-to-task link removed during refresh');
+}
+
+console.log('Board-to-task link preserved');


### PR DESCRIPTION
## Summary
- ensure edges to board/note nodes persist when board refreshes
- keep manual edges while syncing task dependencies
- add regression test for board-to-task links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57d557b948331aafdb8c605f0cc7a