### PR TITLE
Improve inline description editing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -139,6 +139,11 @@
   text-overflow: ellipsis;
 }
 
+.vtasks-desc.vtasks-inline-edit {
+  overflow: visible;
+  text-overflow: initial;
+}
+
 .vtasks-note-link {
   cursor: pointer;
   margin-left: 4px;
@@ -152,15 +157,6 @@
   background: transparent;
   border: none;
   outline: none;
-}
-
-.vtasks-desc-input {
-  width: 100%;
-  resize: none;
-  background: transparent;
-  border: none;
-  outline: none;
-  caret-color: var(--text-normal);
 }
 
 .vtasks-lane {


### PR DESCRIPTION
## Summary
- Start description inline editor on click or typing
- Keep description input minimal like title editing
- Prevent space key from completing task during description edit

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58b4d93e8833183c7535b8ae06db6