### PR TITLE
Add board task completion bar

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -205,7 +205,13 @@ export default class Controller {
   }
 
   async addBoardCard(
-    info: { path: string; name: string; lastModified: number; taskCount: number },
+    info: {
+      path: string;
+      name: string;
+      lastModified: number;
+      taskCount: number;
+      completedCount: number;
+    },
     x: number,
     y: number
   ) {
@@ -220,6 +226,7 @@ export default class Controller {
       name: info.name,
       lastModified: info.lastModified,
       taskCount: info.taskCount,
+      completedCount: info.completedCount,
     } as NodeData;
     await saveBoard(this.app, this.boardFile, this.board);
     return id;

--- a/styles.css
+++ b/styles.css
@@ -562,7 +562,11 @@ textarea.vtasks-edge-label-input {
 }
 
 .vtasks-board.drag-over {
-  background: #e0f7fa;
+  background: rgba(var(--interactive-accent-rgb), 0.15);
+}
+
+.theme-dark .vtasks-board.drag-over {
+  background: rgba(var(--interactive-accent-rgb), 0.3);
 }
 
 .vtasks-board-card {
@@ -573,6 +577,22 @@ textarea.vtasks-edge-label-input {
   color: var(--text-normal);
   cursor: pointer;
   transition: box-shadow 0.2s, background 0.2s;
+}
+
+.vtasks-board-card .vtasks-progress {
+  width: 100%;
+  height: 6px;
+  background: var(--background-modifier-border);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.vtasks-board-card .vtasks-progress-bar {
+  height: 100%;
+  width: 0%;
+  background: var(--interactive-accent);
+  transition: width 0.3s ease;
 }
 
 .vtasks-board-card:hover {


### PR DESCRIPTION
## Summary
- Show task completion progress bar inside board cards using Obsidian accent colors
- Compute and store task completion stats for board cards
- Use accent-based background for drag-over in dark theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a59144a8148331bd9bc7ab7334aa03