### PR TITLE
Hide alignment guides after resize and handle pointercancel

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -1419,7 +1419,7 @@ export class BoardView extends ItemView {
       }
     };
 
-    this.boardEl.onpointerup = (e) => {
+    const handlePointerUp = (e: PointerEvent) => {
       (this.boardEl as HTMLElement).releasePointerCapture((e as PointerEvent).pointerId);
       if (this.resizingLaneId) {
         const id = this.resizingLaneId;
@@ -1439,6 +1439,8 @@ export class BoardView extends ItemView {
       } else if (this.resizingId) {
         const id = this.resizingId;
         this.resizingId = null;
+        this.alignVLine.style.display = 'none';
+        this.alignHLine.style.display = 'none';
         const pos = this.board!.nodes[id];
         const oldLane = pos.lane;
         const laneId = this.getLaneForNode(id);
@@ -1535,6 +1537,9 @@ export class BoardView extends ItemView {
         });
       }
     };
+
+    this.boardEl.onpointerup = handlePointerUp;
+    this.boardEl.onpointercancel = handlePointerUp;
 
     this.boardEl.onpointerleave = () => {
       if (this.isBoardDragging) {


### PR DESCRIPTION
## Summary
- Hide vertical and horizontal alignment guides when a node resize ends
- Reuse pointerup logic for pointercancel events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5972998508331ae977ab853e6649b