### PR TITLE
feat: make alignment threshold configurable

### DIFF
--- a/src/boardStore.ts
+++ b/src/boardStore.ts
@@ -31,6 +31,8 @@ export interface BoardData {
   snapToGrid?: boolean;
   /** Whether nodes snap to alignment guides */
   snapToGuides?: boolean;
+  /** Threshold (in pixels) for showing alignment guides */
+  alignThreshold?: number;
 }
 
 const CURRENT_VERSION = 1;
@@ -44,6 +46,7 @@ export async function loadBoard(app: App, file: TFile): Promise<BoardData> {
     if (!data.orientation) data.orientation = 'vertical';
     if (data.snapToGrid === undefined) data.snapToGrid = true;
     if (data.snapToGuides === undefined) data.snapToGuides = false;
+    if (data.alignThreshold === undefined) data.alignThreshold = 5;
     return data;
   } catch (e) {
     return {
@@ -55,6 +58,7 @@ export async function loadBoard(app: App, file: TFile): Promise<BoardData> {
       orientation: 'vertical',
       snapToGrid: true,
       snapToGuides: false,
+      alignThreshold: 5,
     };
   }
 }
@@ -92,6 +96,7 @@ export async function getBoardFile(app: App, path: string): Promise<TFile> {
             orientation: 'vertical',
             snapToGrid: true,
             snapToGuides: false,
+            alignThreshold: 5,
           },
           null,
           2

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -132,6 +132,11 @@ export default class Controller {
     await saveBoard(this.app, this.boardFile, this.board);
   }
 
+  async setAlignThreshold(value: number) {
+    this.board.alignThreshold = value;
+    await saveBoard(this.app, this.boardFile, this.board);
+  }
+
   async setLaneOrientation(
     id: string,
     orient: 'vertical' | 'horizontal'

--- a/src/view.ts
+++ b/src/view.ts
@@ -392,6 +392,22 @@ export class BoardView extends ItemView {
             this.render();
           })
       );
+      const alignThreshold = this.board?.alignThreshold ?? 5;
+      menu.addItem((item) =>
+        item.setTitle(`Alignment threshold (${alignThreshold})`).onClick(async () => {
+          const val = await this.promptString(
+            'Alignment threshold',
+            alignThreshold.toString()
+          );
+          if (val !== null) {
+            const num = parseInt(val, 10);
+            if (!isNaN(num)) {
+              await this.controller?.setAlignThreshold(num);
+              this.render();
+            }
+          }
+        })
+      );
       const current = this.board?.orientation ?? 'vertical';
       menu.addItem((item) =>
         item.setTitle('Vertical orientation').onClick(async () => {
@@ -2149,7 +2165,7 @@ export class BoardView extends ItemView {
     h: number,
     dir = ''
   ) {
-    const threshold = 5;
+    const threshold = this.board?.alignThreshold ?? 5;
     const cx = x + w / 2;
     const cy = y + h / 2;
     let alignX: number | null = null;


### PR DESCRIPTION
## Summary
- add `alignThreshold` to board data with default of 5
- expose an "Alignment threshold" board setting
- use board threshold in alignment guide calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a59a92b35c8331b3b758547b6fe9dd