### PR TITLE
Preserve note nodes and edges on refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rollup -c && cp manifest.json styles.css dist/",
     "dev": "rollup -c -w",
-    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts"
+    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteLinks.test.ts"
   },
   "keywords": [
     "obsidian-plugin"

--- a/src/view.ts
+++ b/src/view.ts
@@ -235,6 +235,7 @@ export class BoardView extends ItemView {
 
     for (const id of Object.keys(this.board.nodes)) {
       const n = this.board.nodes[id] as any;
+      if (n.notePath && !n.type) n.type = 'note';
       // Only remove nodes that correspond to tasks no longer present.
       // Preserve board, note and other special nodes which have a type set.
       if (!this.tasks.has(id) && !n.type) delete this.board.nodes[id];
@@ -245,9 +246,12 @@ export class BoardView extends ItemView {
     );
 
     const existing = this.board.edges.filter((e) => {
+      const fromNode = this.board!.nodes[e.from] as any;
+      const toNode = this.board!.nodes[e.to] as any;
       const fromTask = this.tasks.has(e.from);
       const toTask = this.tasks.has(e.to);
-      if (fromTask && toTask) {
+      const involvesNote = fromNode?.type === 'note' || toNode?.type === 'note';
+      if (fromTask && toTask && !involvesNote) {
         return deps.some(
           (d) => d.from === e.from && d.to === e.to && d.type === e.type
         );


### PR DESCRIPTION
## Summary
- mark nodes with `notePath` as `type: note` before pruning
- keep edges connected to note nodes when refreshing from vault
- add regression test for note node and link preservation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b28e6c088331acea90bce850bfda