### PR TITLE
Guard board drop handler when DataTransfer#getData is unavailable

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -908,32 +908,34 @@ export class BoardView extends ItemView {
       }
 
       const text =
-        e.dataTransfer?.getData('text/plain') ||
-        e.dataTransfer?.getData('text/uri-list');
+        e.dataTransfer?.getData?.('text/plain') ||
+        e.dataTransfer?.getData?.('text/uri-list');
       if (text) {
         for (const line of text.split('\n')) {
           processPath(line.trim());
         }
       }
 
-      const dmFile = (this.app as any).dragManager?.getData(
-        e.dataTransfer,
-        'file'
-      );
-      if (dmFile) {
-        const files = Array.isArray(dmFile) ? dmFile : [dmFile];
-        for (const f of files) {
-          processPath(f.path || f, f.name);
+      if (e.dataTransfer?.getData) {
+        const dmFile = (this.app as any).dragManager?.getData?.(
+          e.dataTransfer,
+          'file'
+        );
+        if (dmFile) {
+          const files = Array.isArray(dmFile) ? dmFile : [dmFile];
+          for (const f of files) {
+            processPath(f.path || f, f.name);
+          }
         }
-      }
-      const dmText = (this.app as any).dragManager?.getData(
-        e.dataTransfer,
-        'text'
-      );
-      if (dmText) {
-        const texts = Array.isArray(dmText) ? dmText : [dmText];
-        for (const t of texts) {
-          processPath(t.path || t, t.name);
+        const dmText = (this.app as any).dragManager?.getData?.(
+          e.dataTransfer,
+          'text'
+        );
+        if (dmText) {
+          const texts = Array.isArray(dmText) ? dmText : [dmText];
+          for (const t of texts) {
+            processPath(t.path || t, t.name);
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- handle missing `DataTransfer.getData` in drop handler
- only query `dragManager` when `DataTransfer` supports `getData`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b81ce1e48331a1ed8041ac6bc546