### PR TITLE
Treat notePath nodes as notes

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -595,7 +595,8 @@ export class BoardView extends ItemView {
       return nodeEl;
     }
 
-    if (pos.type === 'note') {
+    if (pos.type === 'note' || pos.notePath) {
+      if (pos.notePath && pos.type !== 'note') pos.type = 'note';
       nodeEl.createDiv(
         `vtasks-handle vtasks-handle-in vtasks-handle-${orientH === 'vertical' ? 'top' : 'left'}`
       );


### PR DESCRIPTION
## Summary
- Render nodes with a `notePath` as note elements by default.
- Preserve board state by assigning `type: 'note'` when a `notePath` is present.

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5bcdd284c8331a3aa68d44b9691b9