### PR TITLE
Handle dropped note links without explicit .md extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@
 1. Launch the **MindTask: Open board** command from the Command Palette.
 2. Drag nodes with your mouse to organize tasks.
 3. Right-click on a node or connection to access the context menu.
+4. Drop note links or files onto the board to create new nodes. Links without the `.md`
+   extension are automatically resolved.
 
 ### Navigation
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rollup -c && cp manifest.json styles.css dist/",
     "dev": "rollup -c -w",
-    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteToNoteLinks.test.ts"
+    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteToNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/dropNoteWithoutExtension.test.ts"
   },
   "keywords": [
     "obsidian-plugin"

--- a/src/view.ts
+++ b/src/view.ts
@@ -896,9 +896,17 @@ export class BoardView extends ItemView {
         name?: string,
         lastModified?: number
       ) => {
-        const rel = toVaultPath(raw);
+        let rel = toVaultPath(raw);
         if (!rel) return;
-        const lower = rel.toLowerCase();
+        let lower = rel.toLowerCase();
+        // Allow dropping paths without extension; try appending ".md" if it exists
+        if (!lower.endsWith('.md')) {
+          const mdCandidate = `${rel}.md`;
+          if (this.app.vault.getAbstractFileByPath(mdCandidate)) {
+            rel = mdCandidate;
+            lower = rel.toLowerCase();
+          }
+        }
         if (lower.endsWith('.mtask')) {
           boardItems.push({
             path: rel,

--- a/test/dropNoteWithoutExtension.test.ts
+++ b/test/dropNoteWithoutExtension.test.ts
@@ -1,0 +1,66 @@
+import { App } from 'obsidian';
+
+const app = new App();
+app.vault.adapter = { basePath: '' } as any;
+app.vault.getAbstractFileByPath = (p: string) =>
+  p === 'Nota.md' ? { path: p, stat: { mtime: 0 }, basename: 'Nota' } : null;
+
+const basePath = '';
+const toVaultPath = (raw: unknown): string | null => {
+  if (raw == null) return null;
+  let p = typeof raw === 'string' ? raw : ((raw as any).path || (raw as any).name || '') + '';
+  p = decodeURI(p).replace(/\\/g, '/');
+  const obsidian = /^obsidian:\/\/open\?(.*)/.exec(p);
+  if (obsidian) {
+    const params = new URLSearchParams(obsidian[1]);
+    const file = params.get('file');
+    if (!file) return null;
+    p = decodeURIComponent(file);
+    if (p.startsWith('/')) p = p.slice(1);
+    return p;
+  }
+  p = p.replace(/^file:\/\//, '').replace(/^app:\/\/local\//, '');
+  if (basePath && p.startsWith(basePath)) {
+    p = p.slice(basePath.length);
+  } else if (basePath && p.includes(':') && !p.startsWith(basePath)) {
+    return null;
+  }
+  if (p.startsWith('/')) p = p.slice(1);
+  return p;
+};
+
+const notePaths: string[] = [];
+function processPath(raw: unknown) {
+  let rel = toVaultPath(raw);
+  if (!rel) return;
+  let lower = rel.toLowerCase();
+  if (!lower.endsWith('.md')) {
+    const mdCandidate = `${rel}.md`;
+    if (app.vault.getAbstractFileByPath(mdCandidate)) {
+      rel = mdCandidate;
+      lower = rel.toLowerCase();
+    }
+  }
+  if (lower.endsWith('.md')) {
+    notePaths.push(rel);
+  }
+}
+
+processPath('obsidian://open?vault=Vault&file=Nota');
+
+let createdPath: string | null = null;
+const controller = {
+  addNoteNode: async (path: string) => {
+    createdPath = path;
+  },
+};
+
+for (const path of notePaths) {
+  await controller.addNoteNode(path);
+}
+
+if (createdPath !== 'Nota.md') {
+  throw new Error('Note link without extension was not resolved correctly');
+}
+
+console.log('Drop without extension creates note node');


### PR DESCRIPTION
## Summary
- resolve dropped paths lacking `.md` extension by checking for the file and appending the extension
- document that dropping note links or files without `.md` is supported
- add regression test to ensure obsidian URLs without extension create note nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5d0f3b5d0833187af1621fb74ef88