### PR TITLE
feat: show editable note titles with link

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -156,6 +156,24 @@
   text-overflow: initial;
 }
 
+.vtasks-note-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.vtasks-note-title {
+  flex: 1;
+  font-weight: bold;
+  font-size: 1.1em;
+  cursor: pointer;
+}
+
+.vtasks-note-open {
+  cursor: pointer;
+  margin-left: 4px;
+}
+
 .vtasks-note-link {
   cursor: pointer;
   margin-left: 4px;


### PR DESCRIPTION
## Summary
- display note title at top of note cards with inline editing
- add link icon to open note in a new tab
- style note header and title

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d8ee96b083318ba90c908398216b