### PR TITLE
Store task descriptions in board file

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -146,7 +146,7 @@
 .vtasks-desc {
   font-size: 0.9em;
   color: var(--text-muted);
-  white-space: normal;
+  white-space: pre-wrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
## Summary
- Save task descriptions directly on board nodes instead of embedding metadata in task text
- Sync board stored descriptions with tasks when loading or refreshing the board
- Allow multiline description editing and display line breaks in the UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a709cbbeac8331aff83c45df111d15