### PR TITLE
fix: preserve edge labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rollup -c && cp manifest.json styles.css dist/",
     "dev": "rollup -c -w",
-    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteToNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/dropNoteWithoutExtension.test.ts"
+    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteToNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/dropNoteWithoutExtension.test.ts && tsx --tsconfig tsconfig.test.json test/preserveEdgeLabels.test.ts"
   },
   "keywords": [
     "obsidian-plugin"

--- a/src/view.ts
+++ b/src/view.ts
@@ -264,9 +264,15 @@ export class BoardView extends ItemView {
     );
 
     // Start with dependency edges between existing nodes
-    const combined = deps.filter(
-      (d) => this.board!.nodes[d.from] && this.board!.nodes[d.to]
-    );
+    // Preserve labels from existing board edges when available
+    const combined = deps
+      .filter((d) => this.board!.nodes[d.from] && this.board!.nodes[d.to])
+      .map((d) => {
+        const match = this.board!.edges.find(
+          (e) => e.from === d.from && e.to === d.to && e.type === d.type
+        );
+        return match && match.label ? { ...d, label: match.label } : d;
+      });
 
     // Merge in existing edges that involve special nodes (type defined)
     for (const e of this.board.edges) {

--- a/test/preserveEdgeLabels.test.ts
+++ b/test/preserveEdgeLabels.test.ts
@@ -1,0 +1,54 @@
+import { JSDOM } from 'jsdom';
+import { BoardView } from '../src/view';
+
+declare global {
+  interface Window { ResizeObserver: any; }
+}
+
+const dom = new JSDOM('<!doctype html><div id="root"></div>');
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const file: any = { path: 'tasks.md', basename: 'tasks' };
+const boardFile: any = { path: 'board.mtask', basename: 'board' };
+
+const app: any = {
+  vault: {
+    getMarkdownFiles: () => [file],
+    read: async () => '- [ ] Task1 ^t1\n- [ ] Task2 [dependsOn:: t1] ^t2\n',
+    modify: async () => {},
+    getAbstractFileByPath: () => null,
+  },
+};
+
+const view: any = {
+  app,
+  boardFile,
+  board: {
+    nodes: {
+      t1: { x: 0, y: 0 },
+      t2: { x: 100, y: 0 },
+    },
+    edges: [{ from: 't1', to: 't2', type: 'depends', label: 'custom' }],
+    lanes: {},
+  },
+  tasks: new Map(),
+  plugin: { settings: { tagFilters: [], folderPaths: [], useBlockId: true } },
+  selectedIds: new Set(),
+  boardEl: dom.window.document.getElementById('root'),
+  render: () => {},
+};
+
+await (BoardView.prototype as any).refreshFromVault.call(view);
+
+const edge = view.board.edges[0];
+if (edge.label !== 'custom') {
+  throw new Error('Edge label removed during refresh');
+}
+
+console.log('Edge label preserved');


### PR DESCRIPTION
## Summary
- keep edge labels when refreshing board data
- add regression test for edge label persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8283532a883318864451bfa40f22a