### PR TITLE
Fix MarkdownRenderer context to prevent addChild errors

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -824,7 +824,7 @@ export class BoardView extends ItemView {
       descEl.style.pointerEvents = 'auto';
       descEl.setAttr('data-raw', description || '');
       if (description) {
-        MarkdownRenderer.renderMarkdown(description, descEl, '', this.app);
+        MarkdownRenderer.renderMarkdown(description, descEl, '', this);
       }
       descEl.addEventListener('click', (e) => {
         if ((e.target as HTMLElement).tagName === 'A') return;
@@ -2245,7 +2245,7 @@ export class BoardView extends ItemView {
       cleanup();
       descEl.setAttr('data-raw', original);
       descEl.empty();
-      MarkdownRenderer.renderMarkdown(original, descEl, '', this.app);
+      MarkdownRenderer.renderMarkdown(original, descEl, '', this);
     };
 
     const onBlur = () => save();


### PR DESCRIPTION
## Summary
- Pass BoardView instance to MarkdownRenderer.renderMarkdown to ensure markdown post-processors receive a Component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a830265ac083318cc737299176b8db