### PR TITLE
Make getState synchronous and test state restoration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rollup -c && cp manifest.json styles.css dist/",
     "dev": "rollup -c -w",
-    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteToNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/dropNoteWithoutExtension.test.ts && tsx --tsconfig tsconfig.test.json test/preserveEdgeLabels.test.ts"
+    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteToNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/dropNoteWithoutExtension.test.ts && tsx --tsconfig tsconfig.test.json test/preserveEdgeLabels.test.ts && tsx --tsconfig tsconfig.test.json test/statePersistence.test.ts"
   },
   "keywords": [
     "obsidian-plugin"

--- a/src/view.ts
+++ b/src/view.ts
@@ -124,7 +124,7 @@ export class BoardView extends ItemView {
   }
 
   // @ts-ignore
-  async getState() {
+  getState() {
     return { file: this.boardFile?.path };
   }
 

--- a/test/statePersistence.test.ts
+++ b/test/statePersistence.test.ts
@@ -1,0 +1,29 @@
+import { BoardView } from '../src/view';
+
+let loadedPath: string | null = null;
+
+const ctx: any = {
+  boardFile: { path: 'Board.mtask' },
+  loadViewData: async (path: string) => {
+    loadedPath = path;
+  },
+};
+
+const state = (BoardView.prototype as any).getState.call(ctx);
+
+if (state instanceof Promise) {
+  throw new Error('getState should return state synchronously');
+}
+
+if (state.file !== 'Board.mtask') {
+  throw new Error('getState did not return the board file path');
+}
+
+ctx.boardFile = null;
+await (BoardView.prototype as any).setState.call(ctx, state);
+
+if (loadedPath !== 'Board.mtask') {
+  throw new Error('setState did not load the correct board file');
+}
+
+console.log('State round-trip loads board file');


### PR DESCRIPTION
## Summary
- Remove unnecessary async from `BoardView.getState` and return the board file path synchronously.
- Add automated test ensuring `setState` reloads the correct `.mtask` file from saved state.
- Update test script to run the new state persistence test.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a831bcd1c083319d751eceda87e70d