### PR TITLE
fix: specify wiki link suggestion element type

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -2225,7 +2225,10 @@ export class BoardView extends ItemView {
     descEl.textContent = original;
     descEl.contentEditable = 'true';
     descEl.classList.add('vtasks-inline-edit');
-    const suggester = new WikiLinkSuggest(this.app, descEl);
+    const suggester = new WikiLinkSuggest(
+      this.app,
+      descEl as HTMLDivElement | HTMLInputElement | HTMLTextAreaElement,
+    );
 
     const cleanup = () => {
       descEl.classList.remove('vtasks-inline-edit');


### PR DESCRIPTION
## Summary
- cast the description element to a more specific HTML element type before creating a wiki link suggester

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a83663cf4c8331bde603336638555c