### PR TITLE
Remove margins from description paragraphs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -151,6 +151,10 @@
   text-overflow: ellipsis;
 }
 
+.vtasks-desc p {
+  margin: 0;
+}
+
 .vtasks-desc.vtasks-inline-edit {
   overflow: visible;
   text-overflow: initial;


### PR DESCRIPTION
## Summary
- ensure task description paragraphs have no default margin by adding `.vtasks-desc p { margin: 0; }`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a845360c28833184849a42db883a21