### PR TITLE
Guard pointerdown during description editing

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -1135,6 +1135,8 @@ export class BoardView extends ItemView {
 
     this.boardEl.onpointerdown = (e) => {
       if ((e as PointerEvent).button === 2) return;
+      const descEl = (e.target as HTMLElement).closest('.vtasks-desc') as HTMLElement | null;
+      if (descEl?.isContentEditable) return;
       this.pointerDownSelected = false;
       this.boardEl.focus();
       if (this.editingId) this.finishEditing(true);
@@ -2286,8 +2288,8 @@ export class BoardView extends ItemView {
     ) as HTMLElement | null;
     if (!descEl) return;
     const original = descEl.getAttr('data-raw') || '';
-    descEl.textContent = original;
     descEl.contentEditable = 'true';
+    descEl.textContent = original;
     descEl.classList.add('vtasks-inline-edit');
     const suggester = new WikiLinkSuggest(
       this.app,


### PR DESCRIPTION
## Summary
- Ignore board pointer events when clicking a task description in edit mode
- Ensure description editing sets `contentEditable` before populating text so pointer guard applies immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a846887688833194783f503b5c8575