### PR TITLE
refactor: ensure descEl non-null

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -856,9 +856,8 @@ export class BoardView extends ItemView {
       }
     }
     textEl.textContent = text.trim();
-    let descEl: HTMLElement | null = null;
     if (pos.type !== 'group') {
-      descEl = nodeEl.createDiv('vtasks-desc');
+      const descEl = nodeEl.createDiv('vtasks-desc');
       descEl.style.pointerEvents = 'auto';
       descEl.setAttr('data-raw', description || '');
       if (description) {


### PR DESCRIPTION
## Summary
- define `descEl` only when rendering non-group nodes to remove null reference warnings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac204082ac8331a827589d5613da9c