### PR TITLE
Add sidebar checkboxes

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -3160,7 +3160,18 @@ export class BoardView extends ItemView {
       for (const node of nodes) {
         const li = ul.createEl('li');
         li.setAttr('data-id', node.id);
-        li.setText(this.getNodeLabel(node.id));
+        const task = this.tasks.get(node.id);
+        if (task) {
+          const checkbox = li.createEl('input', { type: 'checkbox' }) as HTMLInputElement;
+          checkbox.checked = task.checked;
+          checkbox.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.controller!
+              .setCheck(node.id, checkbox.checked)
+              .then(() => this.render());
+          });
+        }
+        li.createSpan({ text: this.getNodeLabel(node.id) });
         if (node.children.length) buildList(node.children, li);
       }
     };

--- a/styles.css
+++ b/styles.css
@@ -683,6 +683,8 @@ textarea.vtasks-edge-label-input {
 .vtasks-sidebar li {
   padding: 2px 4px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .vtasks-sidebar li:hover {
@@ -691,4 +693,8 @@ textarea.vtasks-edge-label-input {
 
 .vtasks-sidebar li.active {
   background: var(--background-modifier-active);
+}
+
+.vtasks-sidebar li input[type='checkbox'] {
+  margin-right: 4px;
 }


### PR DESCRIPTION
## Summary
- Add checkboxes to sidebar task list and wire them to task completion state
- Align sidebar checkboxes and text with new styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac248091e88331a0f35572eb2d027d