### PR TITLE
feat: support node titles

### DIFF
--- a/src/boardStore.ts
+++ b/src/boardStore.ts
@@ -18,6 +18,7 @@ export interface NodeData {
   color?: string;
   lane?: string;
   type?: string;
+  title?: string;
   content?: string;
   attachedTo?: string;
   [key: string]: any;
@@ -50,6 +51,11 @@ export async function loadBoard(app: App, file: TFile): Promise<BoardData> {
     if (data.snapToGrid === undefined) data.snapToGrid = true;
     if (data.snapToGuides === undefined) data.snapToGuides = false;
     if (data.alignThreshold === undefined) data.alignThreshold = 5;
+    for (const node of Object.values(data.nodes)) {
+      if (!node.title) {
+        node.title = (node as any).name || (node as any).text || (node as any).content;
+      }
+    }
     return data;
   } catch (e) {
     return {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -221,6 +221,7 @@ export default class Controller {
     this.board.nodes[id] = {
       x,
       y,
+      title: text,
       ...(descMatch ? { description: descMatch[1].trim() } : {}),
     } as NodeData;
     await saveBoard(this.app, this.boardFile, this.board);
@@ -252,6 +253,7 @@ export default class Controller {
       height: 80,
       type: 'board',
       boardPath: info.path,
+      title: info.name,
       name: info.name,
       lastModified: info.lastModified,
       taskCount: info.taskCount,
@@ -270,6 +272,7 @@ export default class Controller {
       height: 200,
       type: 'note',
       notePath: path,
+      title: path.split('/').pop()?.replace(/\.md$/, ''),
     } as NodeData;
     await saveBoard(this.app, this.boardFile, this.board);
     return id;
@@ -307,7 +310,11 @@ export default class Controller {
 
   async addExistingTask(id: string, x: number, y: number) {
     if (!this.tasks.has(id)) return;
-    this.board.nodes[id] = { x, y } as NodeData;
+    this.board.nodes[id] = {
+      x,
+      y,
+      title: this.tasks.get(id)!.text,
+    } as NodeData;
     await saveBoard(this.app, this.boardFile, this.board);
   }
 
@@ -434,6 +441,10 @@ export default class Controller {
       const metaFormatted = tokens.join('  ');
       return text.trim() + (metaFormatted ? `  ${metaFormatted}` : '');
     });
+    if (this.board.nodes[id]) {
+      this.board.nodes[id].title = text.trim();
+      await saveBoard(this.app, this.boardFile, this.board);
+    }
   }
 
   async setDescription(id: string, descr: string) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -191,6 +191,19 @@ export class BoardView extends ItemView {
     this.tasks = tasks;
     this.controller = controller;
     this.boardFile = boardFile;
+    let changed = false;
+    for (const [id, node] of Object.entries(this.board.nodes)) {
+      if (!node.title) {
+        if (tasks.has(id)) {
+          node.title = tasks.get(id)!.text;
+        } else {
+          const anyNode = node as any;
+          node.title = anyNode.name || anyNode.text || anyNode.content;
+        }
+        if (node.title) changed = true;
+      }
+    }
+    if (changed) void saveBoard(this.app, boardFile, this.board);
     this.app.workspace.trigger('layout-change');
 
     if (!this.vaultEventsRegistered) {
@@ -3180,7 +3193,13 @@ export class BoardView extends ItemView {
 
   private getNodeLabel(id: string): string {
     const n = this.board!.nodes[id];
-    return (n as any).name || (n as any).text || (n as any).content || id;
+    return (
+      n.title ||
+      (n as any).name ||
+      (n as any).text ||
+      (n as any).content ||
+      id
+    );
   }
 
   private centerOnNode(id: string) {


### PR DESCRIPTION
## Summary
- add optional `title` to `NodeData` and populate existing boards
- ensure controllers set or update node titles
- prefer `title` when rendering node labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac26c989ec83318cb9a3715c94c837