### PR TITLE
Fix task tree child generation and sidebar nesting

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -15,13 +15,15 @@ export function buildTaskTree(board: BoardData): TaskTreeNode[] {
     parentCount[edge.to] = (parentCount[edge.to] || 0) + 1;
   }
   const roots = Object.keys(board.nodes).filter((id) => !parentCount[id]);
-  const visited = new Set<string>();
-  const build = (id: string): TaskTreeNode => {
-    if (visited.has(id)) return { id, children: [] };
-    visited.add(id);
+  const build = (id: string, ancestors: Set<string> = new Set()): TaskTreeNode => {
+    if (ancestors.has(id)) {
+      return { id, children: [] };
+    }
+    const next = new Set(ancestors);
+    next.add(id);
     return {
       id,
-      children: (children[id] || []).map((cid) => build(cid)),
+      children: (children[id] || []).map((cid) => build(cid, next)),
     };
   };
   return roots.map((r) => build(r));

--- a/styles.css
+++ b/styles.css
@@ -680,6 +680,11 @@ textarea.vtasks-edge-label-input {
   margin: 0;
 }
 
+.vtasks-sidebar ul ul {
+  padding-left: 1.5em;
+  margin-left: 0.5em;
+}
+
 .vtasks-sidebar li {
   padding: 2px 4px;
   cursor: pointer;

--- a/test/buildTaskTree.test.ts
+++ b/test/buildTaskTree.test.ts
@@ -1,0 +1,26 @@
+import { buildTaskTree } from '../src/sidebar';
+import { BoardData } from '../src/boardStore';
+
+(() => {
+  const board: BoardData = {
+    version: 1,
+    nodes: { a: {}, b: {}, c: {}, d: {} },
+    edges: [
+      { from: 'a', to: 'b', type: 'subtask' },
+      { from: 'c', to: 'b', type: 'subtask' },
+      { from: 'b', to: 'd', type: 'subtask' },
+    ],
+    lanes: {},
+  };
+  const tree = buildTaskTree(board);
+  const expected = [
+    { id: 'a', children: [{ id: 'b', children: [{ id: 'd', children: [] }] }] },
+    { id: 'c', children: [{ id: 'b', children: [{ id: 'd', children: [] }] }] },
+  ];
+  if (JSON.stringify(tree) !== JSON.stringify(expected)) {
+    console.log('Expected:', JSON.stringify(expected, null, 2));
+    console.log('Received:', JSON.stringify(tree, null, 2));
+    throw new Error('buildTaskTree did not generate correct child nodes');
+  }
+  console.log('buildTaskTree generated child nodes correctly');
+})();


### PR DESCRIPTION
## Summary
- ensure `buildTaskTree` builds full child subtrees even when a task has multiple parents
- indent nested lists in the sidebar for clearer subtask hierarchy
- add regression test for `buildTaskTree`

## Testing
- `npx tsx --tsconfig tsconfig.test.json test/buildTaskTree.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2b19b308833190398408ce42f374