### PR TITLE
Fix sidebar height and positioning

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -663,7 +663,8 @@ textarea.vtasks-edge-label-input {
 
 .vtasks-sidebar {
   position: fixed;
-  top: 32px;
+  top: 0;
+  margin-top: 32px;
   left: 0;
   bottom: 0;
   width: 200px;


### PR DESCRIPTION
## Summary
- Ensure the sidebar spans the full page by positioning it at the very top
- Offset sidebar below the top bar using a 32px margin

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ded72948331a43dcb14235c859e