### PR TITLE
Add search input to sidebar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -674,6 +674,16 @@ textarea.vtasks-edge-label-input {
   z-index: 15;
 }
 
+.vtasks-sidebar-search {
+  padding: 4px;
+}
+
+.vtasks-sidebar-search input {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 8px;
+}
+
 .vtasks-sidebar ul {
   list-style: none;
   padding-left: 1em;


### PR DESCRIPTION
## Summary
- Add searchable task list with dedicated input in sidebar
- Filter sidebar tasks on-the-fly based on search query
- Style search box for full width and spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac2efb3fd483318b27fa3d17181953