### PR TITLE
feat: persist sidebar width

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -36,6 +36,8 @@ export interface PluginSettings {
   alignLineColor: string;
   /** Width of alignment guide lines in pixels */
   alignLineWidth: number;
+  /** Width of the sidebar in pixels */
+  sidebarWidth: number;
 }
 
 export interface PluginData {
@@ -62,6 +64,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   rearrangeSpacingY: 40,
   alignLineColor: '',
   alignLineWidth: 1,
+  sidebarWidth: 250,
 };
 
 export class SettingsTab extends PluginSettingTab {

--- a/src/view.ts
+++ b/src/view.ts
@@ -128,12 +128,15 @@ export class BoardView extends ItemView {
     this.sidebarEl.style.width = `${Math.max(100, newWidth)}px`;
   };
 
-  private handleSidebarMouseUp = () => {
+  private handleSidebarMouseUp = async () => {
     if (!this.isSidebarResizing) return;
     this.isSidebarResizing = false;
     document.body.style.cursor = '';
     if (this.sidebarEl) {
       this.sidebarEl.style.cursor = '';
+      this.sidebarStartWidth = this.sidebarEl.getBoundingClientRect().width;
+      this.plugin.settings.sidebarWidth = this.sidebarStartWidth;
+      await this.plugin.savePluginData();
     }
     document.removeEventListener('mousemove', this.handleSidebarMouseMove);
     document.removeEventListener('mouseup', this.handleSidebarMouseUp);
@@ -395,6 +398,7 @@ export class BoardView extends ItemView {
     this.svgEl.addClass('vtasks-edges');
     this.boardEl.appendChild(this.svgEl);
     this.sidebarEl = this.containerEl.createDiv('vtasks-sidebar');
+    this.sidebarEl.style.width = `${this.plugin.settings.sidebarWidth}px`;
     const searchContainer = this.sidebarEl.createDiv('vtasks-sidebar-search');
     this.sidebarSearchInput = searchContainer.createEl('input', {
       type: 'text',


### PR DESCRIPTION
## Summary
- add `sidebarWidth` to plugin settings and defaults
- initialize sidebar width from settings when rendering board view
- save resized sidebar width back to settings for persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac575831408331a032370e77636dcb