### PR TITLE
refactor: share task content parser

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -5,6 +5,7 @@ import { BoardData, NodeData, LaneData, saveBoard } from './boardStore';
 import { ParsedTask } from './parser';
 import { PluginSettings } from './settings';
 import { openTaskEditModal } from './taskEditModal';
+import { parseTaskContent } from './taskContent';
 
 export default class Controller {
   constructor(
@@ -218,10 +219,11 @@ export default class Controller {
       notePath: noteMatch ? noteMatch[1].trim() : undefined,
     };
     this.tasks.set(id, task);
+    const parsed = parseTaskContent(text);
     this.board.nodes[id] = {
       x,
       y,
-      title: text,
+      title: parsed.title,
       ...(descMatch ? { description: descMatch[1].trim() } : {}),
     } as NodeData;
     await saveBoard(this.app, this.boardFile, this.board);
@@ -310,10 +312,12 @@ export default class Controller {
 
   async addExistingTask(id: string, x: number, y: number) {
     if (!this.tasks.has(id)) return;
+    const taskText = this.tasks.get(id)!.text;
+    const { title } = parseTaskContent(taskText);
     this.board.nodes[id] = {
       x,
       y,
-      title: this.tasks.get(id)!.text,
+      title,
     } as NodeData;
     await saveBoard(this.app, this.boardFile, this.board);
   }

--- a/src/taskContent.ts
+++ b/src/taskContent.ts
@@ -1,0 +1,55 @@
+export interface ParsedContent {
+  title: string;
+  metas: Map<string, string>;
+  tags: string[];
+  deps: { dependsOn: string[]; subtaskOf: string[]; after: string[] };
+}
+
+export function parseTaskContent(text: string): ParsedContent {
+  const metas = new Map<string, string>();
+  const tags: string[] = [];
+  const deps = {
+    dependsOn: [] as string[],
+    subtaskOf: [] as string[],
+    after: [] as string[],
+  };
+  let title = text;
+
+  title = title.replace(/\[dependsOn::\s*([^\]]+)\]/g, (_m, v) => {
+    deps.dependsOn.push(v.trim());
+    return '';
+  });
+  title = title.replace(/\[subtaskOf::\s*([^\]]+)\]/g, (_m, v) => {
+    deps.subtaskOf.push(v.trim());
+    return '';
+  });
+  title = title.replace(/\[after::\s*([^\]]+)\]/g, (_m, v) => {
+    deps.after.push(v.trim());
+    return '';
+  });
+
+  title = title.replace(/\[(\w+)::\s*([^\]]+)\]/g, (_m, key, val) => {
+    const k = key.toLowerCase();
+    if (k === 'id') return '';
+    metas.set(key, val.trim());
+    return '';
+  });
+  title = title.replace(
+    /\b(\w+)::\s*((?:\[\[[^\]]+\]\]|[^\n])*?)(?=\s+\w+::|\s+#|$)/g,
+    (_m, key, val) => {
+      const k = key.toLowerCase();
+      if (k === 'id') return '';
+      metas.set(key, val.trim());
+      return '';
+    },
+  );
+  title = title.replace(/#(\S+)/g, (_m, t) => {
+    tags.push('#' + t);
+    return '';
+  });
+  const idMatch = title.trim().match(/\^[\w-]+$/);
+  if (idMatch) {
+    title = title.replace(/\^[\w-]+$/, '');
+  }
+  return { title: title.trim(), metas, tags, deps };
+}

--- a/src/taskEditModal.ts
+++ b/src/taskEditModal.ts
@@ -12,68 +12,13 @@ import { NoteSuggest } from './noteSuggest';
 import WikiLinkSuggest from './wikiLinkSuggest';
 import { ParsedTask } from './parser';
 import { PluginSettings } from './settings';
+import { parseTaskContent } from './taskContent';
 
 export interface EditTaskResult {
   text: string;
   checked: boolean;
   description: string;
   notePath?: string;
-}
-
-interface ParsedContent {
-  title: string;
-  metas: Map<string, string>;
-  tags: string[];
-  deps: { dependsOn: string[]; subtaskOf: string[]; after: string[] };
-}
-
-function parseTaskContent(text: string): ParsedContent {
-  const metas = new Map<string, string>();
-  const tags: string[] = [];
-  const deps = {
-    dependsOn: [] as string[],
-    subtaskOf: [] as string[],
-    after: [] as string[],
-  };
-  let title = text;
-
-  title = title.replace(/\[dependsOn::\s*([^\]]+)\]/g, (_m, v) => {
-    deps.dependsOn.push(v.trim());
-    return '';
-  });
-  title = title.replace(/\[subtaskOf::\s*([^\]]+)\]/g, (_m, v) => {
-    deps.subtaskOf.push(v.trim());
-    return '';
-  });
-  title = title.replace(/\[after::\s*([^\]]+)\]/g, (_m, v) => {
-    deps.after.push(v.trim());
-    return '';
-  });
-
-  title = title.replace(/\[(\w+)::\s*([^\]]+)\]/g, (_m, key, val) => {
-    const k = key.toLowerCase();
-    if (k === 'id') return '';
-    metas.set(key, val.trim());
-    return '';
-  });
-  title = title.replace(
-    /\b(\w+)::\s*((?:\[\[[^\]]+\]\]|[^\n])*?)(?=\s+\w+::|\s+#|$)/g,
-    (_m, key, val) => {
-      const k = key.toLowerCase();
-      if (k === 'id') return '';
-      metas.set(key, val.trim());
-      return '';
-    },
-  );
-  title = title.replace(/#(\S+)/g, (_m, t) => {
-    tags.push('#' + t);
-    return '';
-  });
-  const idMatch = title.trim().match(/\^[\w-]+$/);
-  if (idMatch) {
-    title = title.replace(/\^[\w-]+$/, '');
-  }
-  return { title: title.trim(), metas, tags, deps };
 }
 
 function buildTaskText(

--- a/src/view.ts
+++ b/src/view.ts
@@ -3301,13 +3301,7 @@ export class BoardView extends ItemView {
 
   private getNodeLabel(id: string): string {
     const n = this.board!.nodes[id];
-    return (
-      n.title ||
-      (n as any).name ||
-      (n as any).text ||
-      (n as any).content ||
-      id
-    );
+    return n.title!;
   }
 
   private centerOnNode(id: string) {


### PR DESCRIPTION
## Summary
- move task text parsing to new `taskContent` module
- ensure new and existing task nodes use parsed titles
- simplify node labels to rely on cleaned titles

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5860b21c83318297295686284aa7