### PR TITLE
Handle multiple dependency edge types in task tree

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -6,15 +6,17 @@ export interface TaskTreeNode {
 }
 
 export function buildTaskTree(board: BoardData): TaskTreeNode[] {
-  const children: Record<string, string[]> = {};
-  const parentCount: Record<string, number> = {};
+  const children: Record<string, Set<string>> = {};
+  const parents: Record<string, Set<string>> = {};
+  const hierarchical = new Set(['subtask', 'depends']);
   for (const edge of board.edges) {
-    if (edge.type && edge.type !== 'subtask') continue;
-    if (!children[edge.from]) children[edge.from] = [];
-    children[edge.from].push(edge.to);
-    parentCount[edge.to] = (parentCount[edge.to] || 0) + 1;
+    if (edge.type && !hierarchical.has(edge.type)) continue;
+    if (!children[edge.from]) children[edge.from] = new Set();
+    children[edge.from].add(edge.to);
+    if (!parents[edge.to]) parents[edge.to] = new Set();
+    parents[edge.to].add(edge.from);
   }
-  const roots = Object.keys(board.nodes).filter((id) => !parentCount[id]);
+  const roots = Object.keys(board.nodes).filter((id) => !parents[id]);
   const build = (id: string, ancestors: Set<string> = new Set()): TaskTreeNode => {
     if (ancestors.has(id)) {
       return { id, children: [] };
@@ -23,7 +25,7 @@ export function buildTaskTree(board: BoardData): TaskTreeNode[] {
     next.add(id);
     return {
       id,
-      children: (children[id] || []).map((cid) => build(cid, next)),
+      children: Array.from(children[id] || []).map((cid) => build(cid, next)),
     };
   };
   return roots.map((r) => build(r));

--- a/test/buildTaskTree.test.ts
+++ b/test/buildTaskTree.test.ts
@@ -4,11 +4,13 @@ import { BoardData } from '../src/boardStore';
 (() => {
   const board: BoardData = {
     version: 1,
-    nodes: { a: {}, b: {}, c: {}, d: {} },
+    nodes: { a: {}, b: {}, c: {}, d: {}, e: {} },
     edges: [
       { from: 'a', to: 'b', type: 'subtask' },
-      { from: 'c', to: 'b', type: 'subtask' },
-      { from: 'b', to: 'd', type: 'subtask' },
+      { from: 'a', to: 'b', type: 'depends' },
+      { from: 'c', to: 'b', type: 'depends' },
+      { from: 'b', to: 'd', type: 'depends' },
+      { from: 'b', to: 'e', type: 'sequence' },
     ],
     lanes: {},
   };
@@ -16,11 +18,35 @@ import { BoardData } from '../src/boardStore';
   const expected = [
     { id: 'a', children: [{ id: 'b', children: [{ id: 'd', children: [] }] }] },
     { id: 'c', children: [{ id: 'b', children: [{ id: 'd', children: [] }] }] },
+    { id: 'e', children: [] },
   ];
   if (JSON.stringify(tree) !== JSON.stringify(expected)) {
     console.log('Expected:', JSON.stringify(expected, null, 2));
     console.log('Received:', JSON.stringify(tree, null, 2));
     throw new Error('buildTaskTree did not generate correct child nodes');
   }
-  console.log('buildTaskTree generated child nodes correctly');
+  console.log('buildTaskTree handles depends edges and deduplicates correctly');
+})();
+
+(() => {
+  const board: BoardData = {
+    version: 1,
+    nodes: { a: {}, b: {}, c: {} },
+    edges: [
+      { from: 'a', to: 'b', type: 'sequence' },
+      { from: 'b', to: 'c', type: 'depends' },
+    ],
+    lanes: {},
+  };
+  const tree = buildTaskTree(board);
+  const expected = [
+    { id: 'a', children: [] },
+    { id: 'b', children: [{ id: 'c', children: [] }] },
+  ];
+  if (JSON.stringify(tree) !== JSON.stringify(expected)) {
+    console.log('Expected:', JSON.stringify(expected, null, 2));
+    console.log('Received:', JSON.stringify(tree, null, 2));
+    throw new Error('buildTaskTree did not ignore non-hierarchical edges');
+  }
+  console.log('buildTaskTree ignores non-hierarchical edges');
 })();


### PR DESCRIPTION
## Summary
- handle `depends` edges when building task tree
- support multiple parent relations and dedupe edges to avoid cycles
- add tests for depends edges and ignoring non-hierarchical edges

## Testing
- `npm test`
- `npx tsx --tsconfig tsconfig.test.json test/buildTaskTree.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac5a5a14b08331bbee7501287330da