### PR TITLE
feat: add collapsible sidebar tree

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -3258,6 +3258,20 @@ export class BoardView extends ItemView {
         const li = ul.createEl('li');
         li.setAttr('data-id', node.id);
         const task = this.tasks.get(node.id);
+
+        if (node.children.length) {
+          li.addClass('has-children');
+          const toggle = li.createSpan({ cls: 'vtasks-sidebar-toggle' });
+          setIcon(toggle, 'chevron-down');
+          toggle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const collapsed = li.classList.toggle('collapsed');
+            setIcon(toggle, collapsed ? 'chevron-right' : 'chevron-down');
+          });
+        } else {
+          li.createSpan({ cls: 'vtasks-sidebar-toggle' });
+        }
+
         if (task) {
           const checkbox = li.createEl('input', { type: 'checkbox' }) as HTMLInputElement;
           checkbox.checked = task.checked;

--- a/styles.css
+++ b/styles.css
@@ -709,6 +709,18 @@ textarea.vtasks-edge-label-input {
   align-items: center;
 }
 
+.vtasks-sidebar li.collapsed > ul {
+  display: none;
+}
+
+.vtasks-sidebar-toggle {
+  width: 1em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 4px;
+}
+
 .vtasks-sidebar li:hover {
   background: var(--background-modifier-hover);
 }


### PR DESCRIPTION
## Summary
- Render sidebar tasks as a collapsible tree so parent tasks can expand to reveal subtasks.
- Include toggle icons and styling so parent tasks appear above their children.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5e12daa08331ba29683a3baa580c