### PR TITLE
Fix sidebar task layout

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -3257,11 +3257,12 @@ export class BoardView extends ItemView {
       for (const node of nodes) {
         const li = ul.createEl('li');
         li.setAttr('data-id', node.id);
+        const row = li.createDiv({ cls: 'vtasks-sidebar-item' });
         const task = this.tasks.get(node.id);
 
         if (node.children.length) {
           li.addClass('has-children');
-          const toggle = li.createSpan({ cls: 'vtasks-sidebar-toggle' });
+          const toggle = row.createSpan({ cls: 'vtasks-sidebar-toggle' });
           setIcon(toggle, 'chevron-down');
           toggle.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -3269,11 +3270,11 @@ export class BoardView extends ItemView {
             setIcon(toggle, collapsed ? 'chevron-right' : 'chevron-down');
           });
         } else {
-          li.createSpan({ cls: 'vtasks-sidebar-toggle' });
+          row.createSpan({ cls: 'vtasks-sidebar-toggle' });
         }
 
         if (task) {
-          const checkbox = li.createEl('input', { type: 'checkbox' }) as HTMLInputElement;
+          const checkbox = row.createEl('input', { type: 'checkbox' }) as HTMLInputElement;
           checkbox.checked = task.checked;
           checkbox.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -3282,7 +3283,7 @@ export class BoardView extends ItemView {
               .then(() => this.render());
           });
         }
-        li.createSpan({ text: this.getNodeLabel(node.id) });
+        row.createSpan({ text: this.getNodeLabel(node.id) });
         if (node.children.length) buildList(node.children, li);
       }
     };

--- a/styles.css
+++ b/styles.css
@@ -705,6 +705,10 @@ textarea.vtasks-edge-label-input {
 .vtasks-sidebar li {
   padding: 2px 4px;
   cursor: pointer;
+  display: block;
+}
+
+.vtasks-sidebar-item {
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
## Summary
- Render sidebar tasks in a vertical hierarchy with nested subtasks
- Adjust sidebar CSS to keep child lists below their parents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac63c160148331b67c48bd69cc33c5