### PR TITLE
Preserve collapsed sidebar on board updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rollup -c && cp manifest.json styles.css dist/",
     "dev": "rollup -c -w",
-    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteToNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/dropNoteWithoutExtension.test.ts && tsx --tsconfig tsconfig.test.json test/preserveEdgeLabels.test.ts && tsx --tsconfig tsconfig.test.json test/statePersistence.test.ts && tsx --tsconfig tsconfig.test.json test/addPostItPersistence.test.ts"
+    "test": "tsx --tsconfig tsconfig.test.json test/boardHandles.test.ts && tsx --tsconfig tsconfig.test.json test/connectedHandles.test.ts && tsx --tsconfig tsconfig.test.json test/preserveBoardLinks.test.ts && tsx --tsconfig tsconfig.test.json test/selectionHighlight.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/preserveNoteToNoteLinks.test.ts && tsx --tsconfig tsconfig.test.json test/dropNoteWithoutExtension.test.ts && tsx --tsconfig tsconfig.test.json test/preserveEdgeLabels.test.ts && tsx --tsconfig tsconfig.test.json test/statePersistence.test.ts && tsx --tsconfig tsconfig.test.json test/addPostItPersistence.test.ts && tsx --tsconfig tsconfig.test.json test/sidebarCollapse.test.ts"
   },
   "keywords": [
     "obsidian-plugin"

--- a/src/view.ts
+++ b/src/view.ts
@@ -121,6 +121,7 @@ export class BoardView extends ItemView {
   private isSidebarResizing = false;
   private sidebarStartWidth = 0;
   private sidebarStartX = 0;
+  private sidebarCollapsed = false;
 
   private handleSidebarMouseMove = (e: MouseEvent) => {
     if (!this.isSidebarResizing || !this.sidebarEl) return;
@@ -145,6 +146,7 @@ export class BoardView extends ItemView {
   private toggleSidebar = () => {
     if (!this.sidebarEl || !this.sidebarToggleBtn) return;
     const collapsed = this.sidebarEl.classList.toggle('collapsed');
+    this.sidebarCollapsed = collapsed;
     setIcon(this.sidebarToggleBtn, collapsed ? 'chevron-right' : 'chevron-left');
   };
 
@@ -399,6 +401,7 @@ export class BoardView extends ItemView {
     this.boardEl.appendChild(this.svgEl);
     this.sidebarEl = this.containerEl.createDiv('vtasks-sidebar');
     this.sidebarEl.style.width = `${this.plugin.settings.sidebarWidth}px`;
+    if (this.sidebarCollapsed) this.sidebarEl.addClass('collapsed');
     const searchContainer = this.sidebarEl.createDiv('vtasks-sidebar-search');
     this.sidebarSearchInput = searchContainer.createEl('input', {
       type: 'text',
@@ -469,7 +472,10 @@ export class BoardView extends ItemView {
     const zoomSection = toolbar.createDiv('vtasks-toolbar-section');
 
     this.sidebarToggleBtn = zoomSection.createEl('button');
-    setIcon(this.sidebarToggleBtn, 'chevron-left');
+    setIcon(
+      this.sidebarToggleBtn,
+      this.sidebarCollapsed ? 'chevron-right' : 'chevron-left'
+    );
     this.sidebarToggleBtn.setAttr('title', 'Toggle sidebar');
     this.sidebarToggleBtn.onclick = () => this.toggleSidebar();
 

--- a/test/sidebarCollapse.test.ts
+++ b/test/sidebarCollapse.test.ts
@@ -1,0 +1,68 @@
+import { JSDOM } from 'jsdom';
+import { BoardView } from '../src/view';
+import { WorkspaceLeaf } from 'obsidian';
+
+const dom = new JSDOM('<!doctype html><div id="root"></div>');
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+
+const proto = dom.window.HTMLElement.prototype as any;
+proto.createDiv = function(arg: any) {
+  const el = dom.window.document.createElement('div');
+  if (typeof arg === 'string') {
+    el.className = arg;
+  } else if (arg?.cls) {
+    el.className = arg.cls;
+  }
+  if (typeof arg === 'object' && arg?.text) {
+    el.textContent = arg.text;
+  }
+  this.appendChild(el);
+  return el;
+};
+proto.createSpan = function(arg: any) {
+  const el = dom.window.document.createElement('span');
+  if (arg?.cls) el.className = arg.cls;
+  if (arg?.text) el.textContent = arg.text;
+  this.appendChild(el);
+  return el;
+};
+proto.createEl = function(tag: string, opts: any = {}) {
+  const el = dom.window.document.createElement(tag);
+  if (opts.cls) el.className = opts.cls;
+  if (opts.text) el.textContent = opts.text;
+  for (const k of Object.keys(opts)) {
+    if (k !== 'cls' && k !== 'text') el.setAttribute(k, opts[k]);
+  }
+  this.appendChild(el);
+  return el;
+};
+proto.empty = function() { this.innerHTML = ''; };
+proto.addClass = function(cls: string) { this.classList.add(cls); };
+proto.removeClass = function(cls: string) { this.classList.remove(cls); };
+proto.toggleClass = function(cls: string, force?: boolean) { this.classList.toggle(cls, force); };
+proto.setText = function(text: string) { this.textContent = text; };
+
+const elemProto = dom.window.Element.prototype as any;
+elemProto.setAttr = function(name: string, value: string) { this.setAttribute(name, value); };
+elemProto.getAttr = function(name: string) { return this.getAttribute(name); };
+
+const svgProto = dom.window.SVGElement.prototype as any;
+svgProto.addClass = function(cls: string) { this.classList.add(cls); };
+svgProto.removeClass = function(cls: string) { this.classList.remove(cls); };
+svgProto.empty = function() { while (this.firstChild) this.removeChild(this.firstChild); };
+
+const plugin: any = { settings: { sidebarWidth: 200 }, savePluginData: async () => {} };
+const view = new BoardView(new WorkspaceLeaf(), plugin);
+(view as any).board = { version: 1, nodes: {}, edges: [], lanes: {}, orientation: 'vertical', snapToGrid: true, snapToGuides: false, alignThreshold: 5 };
+(view as any).tasks = new Map();
+
+(view as any).render();
+(view as any).toggleSidebar();
+(view as any).render();
+
+if (!(view as any).sidebarEl.classList.contains('collapsed')) {
+  throw new Error('Collapsed sidebar should remain collapsed after render');
+}
+
+console.log('Collapsed sidebar remains collapsed after render');


### PR DESCRIPTION
## Summary
- Keep track of sidebar collapsed state and restore it on render
- Initialize sidebar toggle icon based on collapsed state
- Add regression test ensuring collapsed sidebar persists across re-renders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac64c5e25483318137113f94a59402