### PR TITLE
feat: show icons for board and post-it nodes in sidebar

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -3289,6 +3289,13 @@ export class BoardView extends ItemView {
               .then(() => this.render());
           });
         }
+        const nodeData = this.board!.nodes[node.id];
+        if (nodeData?.type === 'postit') {
+          const icon = row.createSpan({ cls: 'vtasks-sidebar-postit-icon' });
+          if (nodeData.color) icon.style.backgroundColor = nodeData.color;
+        } else if (nodeData?.type === 'board') {
+          row.createSpan({ cls: 'vtasks-sidebar-board-icon' });
+        }
         row.createSpan({ text: this.getNodeLabel(node.id) });
         if (node.children.length) buildList(node.children, li);
       }

--- a/styles.css
+++ b/styles.css
@@ -736,3 +736,20 @@ textarea.vtasks-edge-label-input {
 .vtasks-sidebar li input[type='checkbox'] {
   margin-right: 4px;
 }
+
+.vtasks-sidebar-postit-icon,
+.vtasks-sidebar-board-icon {
+  width: 10px;
+  height: 10px;
+  display: inline-block;
+  margin-right: 4px;
+}
+
+.vtasks-sidebar-postit-icon {
+  border-radius: 2px;
+}
+
+.vtasks-sidebar-board-icon {
+  border: 2px dashed currentColor;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- show colored post-it icon next to post-it items in sidebar
- show rounded dashed square icon next to `.mtask` board items in sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac6b65c550833187a9fd32f96754be